### PR TITLE
Update to 0.6.5-SNAPSHOT.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 project.ext {
-    SPINE_VERSION = '0.6.2-SNAPSHOT';
+    SPINE_VERSION = '0.6.5-SNAPSHOT';
     PROTOBUF_VERSION = '3.0.0';
     SLf4J_VERSION = "1.7.21";
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}";

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
         compile group: 'org.spine3', name: 'examples', version: "0.2", changing: true
 
         // Guava
-        compile group: 'com.google.guava', name: 'guava', version: '19.0'
+        compile group: 'com.google.guava', name: 'guava', version: '20.0'
 
         // Findbugs
         compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0'

--- a/credentials.properties.enc
+++ b/credentials.properties.enc
@@ -1,1 +1,1 @@
-Ïd$l—d`Õ;ƒþe¨¼Q;w8=?Áx*kGwÉšr³Â¤Z}òCSS¶…J‰PrprºÆñ-åML>û
+ú!QSªÞO,èÕW[%ˆyŽ¬Î‡˜cÙø¯›æÞuq¢ÅžºÇ5Ê3´jËþ*6@Hñ+A*Yºôaü™ƒag

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -29,11 +29,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
-import org.spine3.base.Event;
-import org.spine3.base.EventContext;
-import org.spine3.base.EventId;
-import org.spine3.base.FieldFilter;
-import org.spine3.base.Identifiers;
+import org.spine3.base.*;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.Timestamps;
 import org.spine3.protobuf.TypeUrl;
@@ -53,11 +49,11 @@ import static com.google.cloud.datastore.StructuredQuery.CompositeFilter;
 import static com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Throwables.propagate;
 import static org.spine3.base.Identifiers.idToString;
 import static org.spine3.server.storage.datastore.DatastoreProperties.TIMESTAMP_NANOS_PROPERTY_NAME;
 import static org.spine3.server.storage.datastore.Entities.entityToMessage;
 import static org.spine3.server.storage.datastore.Entities.messageToEntity;
+import static org.spine3.util.Exceptions.wrapped;
 
 /**
  * Storage for event records based on Google Cloud Datastore.
@@ -305,7 +301,7 @@ import static org.spine3.server.storage.datastore.Entities.messageToEntity;
                 final Method fieldGetter = messageClass.getDeclaredMethod(fieldGetterName);
                 actualValue = (Message) fieldGetter.invoke(object);
             } catch (@SuppressWarnings("OverlyBroadCatchBlock") ReflectiveOperationException e) {
-                throw propagate(e);
+                throw wrapped(e);
             }
 
             final boolean result = expectedValues.contains(actualValue);

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -287,19 +287,21 @@ import static org.spine3.util.Exceptions.wrapped;
                 Message object,
                 @SuppressWarnings("TypeMayBeWeakened") /*BuilderOrType interface*/ FieldFilter filter) {
             final String fieldPath = filter.getFieldPath();
-            final String fieldName = fieldPath.substring(fieldPath.lastIndexOf('.'));
+            final String fieldName = fieldPath.substring(fieldPath.lastIndexOf('.') + 1);
             checkArgument(!Strings.isNullOrEmpty(fieldName), "Field filter " + filter.toString() + " is invalid");
             final String fieldGetterName = "get" + fieldName.substring(0, 1)
                                                             .toUpperCase() + fieldName.substring(1);
 
             final Collection<Any> expectedAnys = filter.getValueList();
             final Collection<Message> expectedValues = Collections2.transform(expectedAnys, ANY_UNPACKER);
-            final Message actualValue;
-
+            Message actualValue;
             try {
                 final Class<?> messageClass = object.getClass();
                 final Method fieldGetter = messageClass.getDeclaredMethod(fieldGetterName);
                 actualValue = (Message) fieldGetter.invoke(object);
+                if (actualValue instanceof Any) {
+                    actualValue = AnyPacker.unpack((Any) actualValue);
+                }
             } catch (@SuppressWarnings("OverlyBroadCatchBlock") ReflectiveOperationException e) {
                 throw wrapped(e);
             }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Throwables.propagate;
+import static org.spine3.util.Exceptions.wrapped;
 
 /**
  * Utility class for converting {@link Message proto messages} into {@link Entity Entities} and vise versa.
@@ -154,7 +154,7 @@ import static com.google.common.base.Throwables.propagate;
             message = (M) factoryMethod.invoke(null);
             return message;
         } catch (@SuppressWarnings("OverlyBroadCatchBlock") ReflectiveOperationException | ClassCastException e) {
-            throw propagate(e);
+            throw wrapped(e);
         }
     }
 }

--- a/script/publish_artifacts.sh
+++ b/script/publish_artifacts.sh
@@ -10,7 +10,7 @@ echo " -- PUBLISHING: current branch is $TRAVIS_BRANCH."
 
 if [ "$TRAVIS_BRANCH" == 'master' ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     echo " ------ Publishing the artifacts to the repository..."
-    openssl aes-256-cbc -K $encrypted_0f12c1faf1fc_key -iv $encrypted_0f12c1faf1fc_iv -in credentials.properties.enc -out credentials.properties -d
+    openssl aes-256-cbc -K $encrypted_0561e108020c_key -iv $encrypted_0561e108020c_iv -in credentials.properties.enc -out credentials.properties -d
     ./gradlew publish -x test
     echo " ------ Artifacts published."
 else


### PR DESCRIPTION
Summary of changes.

* Update the `core-java` dependency to the latest `0.6.5-SNAPSHOT` version.
* Bump `gae-java` version to `0.6.5-SNAPSHOT` as well.
* Migrate to Guava 20.0 (as `core-java` migrated to 20.0 in the most recent version) and update the codebase accordingly.
* Fix the failed tests making `gae-java` compatible with the latest `core-java` changes.