### PR TITLE
Support request fixes

### DIFF
--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
@@ -21,6 +21,7 @@
 package org.spine3.server.storage.datastore;
 
 import com.google.cloud.datastore.Blob;
+import com.google.cloud.datastore.BlobValue;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.common.collect.ImmutableList;
@@ -136,8 +137,11 @@ import static org.spine3.util.Exceptions.wrapped;
         final Any wrapped = AnyPacker.pack(message);
         final byte[] messageBytes = wrapped.getValue().toByteArray();
         final Blob valueBlob = Blob.copyFrom(messageBytes);
+        final BlobValue blobValue = BlobValue.newBuilder(valueBlob)
+                                             .setExcludeFromIndexes(true)
+                                             .build();
         final Entity entity = Entity.newBuilder(key)
-                                    .set(VALUE_PROPERTY_NAME, valueBlob)
+                                    .set(VALUE_PROPERTY_NAME, blobValue)
                                     .build();
         return entity;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/IdTransformer.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/IdTransformer.java
@@ -213,8 +213,9 @@ import static com.google.common.base.Preconditions.checkArgument;
         final String[] separateStringBytes = bytesString.split(SERIALIZED_MESSAGE_BYTES_DIVIDER);
         final byte[] messageBytes = new byte[separateStringBytes.length];
         for (int i = 0; i < messageBytes.length; i++) {
-            final byte oneByte = Byte.parseByte(separateStringBytes[i], SERIALIZED_BYTES_RADIX);
-            messageBytes[i] = oneByte;
+            final byte[] singleByteAsArray = BaseEncoding.base16()
+                                        .decode(separateStringBytes[i]);
+            messageBytes[i] = singleByteAsArray[0];
         }
 
         final ByteString byteString = ByteString.copyFrom(messageBytes);

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreStorageFactory.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreStorageFactory.java
@@ -64,7 +64,11 @@ import static com.google.common.base.Preconditions.checkState;
                                    .setProjectId(DEFAULT_DATASET_NAME).setCredentials(credentials)
                                    .build();
         } catch (@SuppressWarnings("OverlyBroadCatchBlock") IOException e) {
-            throw new RuntimeException(e);
+            log().warn("Cannot find the configuration file {}", CREDENTIALS_FILE_PATH);
+            final DatastoreOptions defaultOptions = DatastoreOptions.newBuilder()
+                                                                    .setProjectId(DEFAULT_DATASET_NAME)
+                                                                    .build();
+            return defaultOptions;
         }
     }
 

--- a/script/start-datastore.bat
+++ b/script/start-datastore.bat
@@ -1,1 +1,1 @@
-gcloud beta emulators datastore start --project=spine --host-port=localhost:8080 --consistency 1.0 --no-store-on-disk
+gcloud beta emulators datastore start --project=spine-dev --host-port=localhost:8080 --consistency 1.0 --no-store-on-disk


### PR DESCRIPTION
Summary of changes:

* Fix ID conversion from `byte[]` to `Message`: use the same mechanism as for `Message` -> `byte[]`. 
* Set BLOB entity fields as unindexed by the Datastore explicitly to avoid 1500 bytes per indexed BLOB restriction.