### PR TITLE
Migrate to GCD Java v.0.8.0-beta

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 project.ext {
-    SPINE_VERSION = '0.6.5-SNAPSHOT';
+    SPINE_VERSION = '0.6.12-SNAPSHOT';
     PROTOBUF_VERSION = '3.0.0';
     SLf4J_VERSION = "1.7.21";
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}";

--- a/gcd/build.gradle
+++ b/gcd/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile group: 'org.spine3', name: 'server', version: project.SPINE_VERSION, changing: true
 
     // Google Cloud Datastore
-    compile 'com.google.cloud:google-cloud-datastore:0.6.0'
+    compile 'com.google.cloud:google-cloud-datastore:0.8.0-beta'
 
     testCompile group: 'org.spine3', name: 'server', version: project.SPINE_VERSION, changing: true, classifier: 'test'
     testCompile group: 'org.spine3', name: 'client', version: project.SPINE_VERSION, changing: true, classifier: 'test'


### PR DESCRIPTION
Summary of changes:

* Migrate to the latest `com.google.cloud:google-cloud-datastore:0.8.0-beta`.
* Migrate to the latest Spine `0.6.12-SNAPSHOT` and own bump version accordingly.