### PR TITLE
Improve testing on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ before_install:
   - openssl aes-256-cbc -K $encrypted_16408b1fb58f_key -iv $encrypted_16408b1fb58f_iv -in ./spine-dev-62685282c0b9.json.enc -out ./gcd/src/test/resources/spine-dev-62685282c0b9.json -d
 
 script:
-  - ./gradlew build --debug
-  - ./gradlew codeCoverageReport
+  - ./gradlew build codeCoverageReport --debug
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 project.ext {
     SPINE_VERSION = '0.7.5-SNAPSHOT'
-    GAE_JAVA_VERSION = "0.7.1-SNAPSHOT"
+    GAE_JAVA_VERSION = "0.7.2-SNAPSHOT"
     PROTOBUF_VERSION = '3.1.0'
     SLf4J_VERSION = "1.7.21"
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}"

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ task startDatastore {
     group "Build Setup"
 }
 
-startDatastore << {
+startDatastore.doLast {
     // Start Datastore emulator with the CLI command
     "${IS_WINDOWS ? '' : '.'}${File.separatorChar}script${File.separatorChar}start-datastore.${IS_WINDOWS ? 'bat' : 'sh'}".execute()
 }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -76,22 +76,28 @@ class TestDatastoreWrapper extends DatastoreWrapper {
     }
 
     @Override
-    Entity read(Key key) {
+    void createOrUpdate(Entity entity) {
+        super.createOrUpdate(entity);
         waitForConsistency();
-        return super.read(key);
     }
 
-    @Override
-    List<Entity> read(Iterable<Key> keys) {
-        waitForConsistency();
-        return super.read(keys);
-    }
-
-    @Override
-    List<Entity> read(Query query) {
-        waitForConsistency();
-        return super.read(query);
-    }
+    //    @Override
+//    Entity read(Key key) {
+//        waitForConsistency();
+//        return super.read(key);
+//    }
+//
+//    @Override
+//    List<Entity> read(Iterable<Key> keys) {
+//        waitForConsistency();
+//        return super.read(keys);
+//    }
+//
+//    @Override
+//    List<Entity> read(Query query) {
+//        waitForConsistency();
+//        return super.read(query);
+//    }
 
     @Override
     void dropTable(String table) {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -46,8 +46,8 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
     // Default time to wait before each read operation to ensure the data is consistent.
     // NOTE: enabled only if {@link #shouldWaitForConsistency} is {@code true}.
-    private static final int CONSISTENCY_AWAIT_TIME_MS = 8;
-    private static final int CONSISTENCY_AWAIT_ITERATIONS = 16;
+    private static final int CONSISTENCY_AWAIT_TIME_MS = 10;
+    private static final int CONSISTENCY_AWAIT_ITERATIONS = 20;
 
     /**
      * Due to eventual consistency, {@link #dropTable(String) is performed iteratively until the table has no records}.

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -21,6 +21,7 @@
 package org.spine3.server.storage.datastore;
 
 import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
@@ -81,23 +82,17 @@ class TestDatastoreWrapper extends DatastoreWrapper {
         waitForConsistency();
     }
 
-    //    @Override
-//    Entity read(Key key) {
-//        waitForConsistency();
-//        return super.read(key);
-//    }
-//
-//    @Override
-//    List<Entity> read(Iterable<Key> keys) {
-//        waitForConsistency();
-//        return super.read(keys);
-//    }
-//
-//    @Override
-//    List<Entity> read(Query query) {
-//        waitForConsistency();
-//        return super.read(query);
-//    }
+    @Override
+    void create(Entity entity) throws DatastoreException {
+        super.create(entity);
+        waitForConsistency();
+    }
+
+    @Override
+    void update(Entity entity) throws DatastoreException {
+        super.update(entity);
+        waitForConsistency();
+    }
 
     @Override
     void dropTable(String table) {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -45,8 +45,8 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
     // Default time to wait before each read operation to ensure the data is consistent.
     // NOTE: enabled only if {@link #shouldWaitForConsistency} is {@code true}.
-    private static final int CONSISTENCY_AWAIT_TIME_MS = 4;
-    private static final int CONSISTENCY_AWAIT_ITERATIONS = 10;
+    private static final int CONSISTENCY_AWAIT_TIME_MS = 5;
+    private static final int CONSISTENCY_AWAIT_ITERATIONS = 16;
 
     /**
      * Due to eventual consistency, {@link #dropTable(String) is performed iteratively until the table has no records}.

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -45,8 +45,8 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
     // Default time to wait before each read operation to ensure the data is consistent.
     // NOTE: enabled only if {@link #shouldWaitForConsistency} is {@code true}.
-    private static final int CONSISTENCY_AWAIT_TIME_MS = 75;
-    private static final int CONSISTENCY_AWAIT_ITERATIONS = 20;
+    private static final int CONSISTENCY_AWAIT_TIME_MS = 4;
+    private static final int CONSISTENCY_AWAIT_ITERATIONS = 10;
 
     /**
      * Due to eventual consistency, {@link #dropTable(String) is performed iteratively until the table has no records}.

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -46,7 +46,7 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
     // Default time to wait before each read operation to ensure the data is consistent.
     // NOTE: enabled only if {@link #shouldWaitForConsistency} is {@code true}.
-    private static final int CONSISTENCY_AWAIT_TIME_MS = 5;
+    private static final int CONSISTENCY_AWAIT_TIME_MS = 8;
     private static final int CONSISTENCY_AWAIT_ITERATIONS = 16;
 
     /**


### PR DESCRIPTION
 - Now a Travis build lasts about `3:50` instead of `20 minutes`
 - Now all the consistency awaits happen after the write operations, not before the read operations
 - If `gradlew build` failes, `gradlew codeCoverageReport` does not execute tests once again