### PR TITLE
Make Datastore-based `Storage`s extensible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 project.ext {
     SPINE_VERSION = '0.7.5-SNAPSHOT'
-    GAE_JAVA_VERSION = "0.7.2-SNAPSHOT"
+    GAE_JAVA_VERSION = "0.7.3-SNAPSHOT"
     PROTOBUF_VERSION = '3.1.0'
     SLf4J_VERSION = "1.7.21"
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 project.ext {
-    SPINE_VERSION = '0.7.5-SNAPSHOT'
-    GAE_JAVA_VERSION = "0.7.3-SNAPSHOT"
+    SPINE_VERSION = '0.7.9-SNAPSHOT'
+    GAE_JAVA_VERSION = "0.7.9-SNAPSHOT"
     PROTOBUF_VERSION = '3.1.0'
     SLf4J_VERSION = "1.7.21"
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}"

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
@@ -26,6 +26,7 @@ import com.google.cloud.datastore.KeyFactory;
 import org.spine3.base.CommandId;
 import org.spine3.base.EventId;
 import org.spine3.base.Identifiers;
+import org.spine3.server.stand.AggregateStateId;
 import org.spine3.server.storage.EventStorageRecord;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -79,13 +80,20 @@ public class DatastoreIdentifiers {
      * @return the Datastore record identifier
      */
     public static DatastoreRecordId ofEntityId(Object id) {
-        //TODO:01-19-17:alex.tymchenko: why do we have both `IdTransformer` and `Identifiers`?
+        if (id instanceof DatastoreRecordId) {
+            return (DatastoreRecordId) id;
+        }
         final String idAsString = IdTransformer.idToString(id);
         return of(idAsString);
     }
 
     public static DatastoreRecordId of(CommandId commandId) {
         final String idAsString = Identifiers.idToString(commandId);
+        return of(idAsString);
+    }
+
+    public static DatastoreRecordId of(AggregateStateId id) {
+        final String idAsString = IdTransformer.idToString(id.getAggregateId());
         return of(idAsString);
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
@@ -25,12 +25,11 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import org.spine3.base.CommandId;
 import org.spine3.base.EventId;
-import org.spine3.base.Identifiers;
+import org.spine3.server.event.storage.EventStorageRecord;
 import org.spine3.server.stand.AggregateStateId;
-import org.spine3.server.storage.EventStorageRecord;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.spine3.base.Identifiers.idToString;
+import static org.spine3.base.Stringifiers.idToString;
 
 /**
  * Utilities for working with GAE Datastore record identifiers and keys.
@@ -90,7 +89,7 @@ public class DatastoreIdentifiers {
     }
 
     public static DatastoreRecordId of(CommandId commandId) {
-        final String idAsString = Identifiers.idToString(commandId);
+        final String idAsString = idToString(commandId);
         return of(idAsString);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
@@ -37,7 +37,9 @@ import static org.spine3.base.Identifiers.idToString;
  *
  * @author Alex Tymchenko
  */
-@SuppressWarnings("UtilityClass")
+@SuppressWarnings({
+        "UtilityClass",
+        "WeakerAccess"  /* as it's part of API */})
 public class DatastoreIdentifiers {
     private DatastoreIdentifiers() {
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
@@ -40,6 +40,7 @@ import static org.spine3.base.Stringifiers.idToString;
         "UtilityClass",
         "WeakerAccess"  /* as it's part of API */})
 public class DatastoreIdentifiers {
+
     private DatastoreIdentifiers() {
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreIdentifiers.java
@@ -1,0 +1,91 @@
+/*
+ *
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package org.spine3.server.storage.datastore;
+
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import org.spine3.base.CommandId;
+import org.spine3.base.EventId;
+import org.spine3.base.Identifiers;
+import org.spine3.server.storage.EventStorageRecord;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.spine3.base.Identifiers.idToString;
+
+/**
+ * Utilities for working with GAE Datastore record identifiers and keys.
+ *
+ * @author Alex Tymchenko
+ */
+@SuppressWarnings("UtilityClass")
+public class DatastoreIdentifiers {
+    private DatastoreIdentifiers() {
+    }
+
+    /**
+     * Creates an instance of {@link com.google.cloud.datastore.Key} basing on the Datastore entity {@code kind}
+     * and {@code recordId}.
+     *
+     * @param datastore the instance of {@code datastore} to create a {@code Key} for
+     * @param kind      the kind of the Datastore entity
+     * @param recordId  the ID of the record
+     * @return the Datastore {@code Key} instance
+     */
+    static Key keyFor(DatastoreWrapper datastore, String kind, DatastoreRecordId recordId) {
+        final KeyFactory keyFactory = datastore.getKeyFactory(kind);
+        final Key key = keyFactory.newKey(recordId.getValue());
+
+        return key;
+    }
+
+    public static DatastoreRecordId of(String value) {
+        checkState(!value.isEmpty());
+        return new DatastoreRecordId(value);
+    }
+
+    public static DatastoreRecordId of(EventStorageRecord record) {
+        return of(record.getEventId());
+    }
+
+    public static DatastoreRecordId of(EventId eventId) {
+        final String idString = idToString(eventId);
+        return of(idString);
+    }
+
+    /**
+     * Creates an instance of {@code DatastoreRecordId} for a given {@link org.spine3.server.entity.Entity}
+     * identifier.
+     *
+     * @param id an identifier of an {@code Entity}
+     * @return the Datastore record identifier
+     */
+    public static DatastoreRecordId ofEntityId(Object id) {
+        //TODO:01-19-17:alex.tymchenko: why do we have both `IdTransformer` and `Identifiers`?
+        final String idAsString = IdTransformer.idToString(id);
+        return of(idAsString);
+    }
+
+    public static DatastoreRecordId of(CommandId commandId) {
+        final String idAsString = Identifiers.idToString(commandId);
+        return of(idAsString);
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreProperties.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreProperties.java
@@ -25,9 +25,9 @@ import com.google.cloud.datastore.Entity;
 import com.google.protobuf.Message;
 import com.google.protobuf.TimestampOrBuilder;
 import org.spine3.base.EventContextOrBuilder;
-import org.spine3.base.Identifiers;
+import org.spine3.base.Stringifiers;
 import org.spine3.protobuf.Messages;
-import org.spine3.server.storage.EventStorageRecordOrBuilder;
+import org.spine3.server.event.storage.EventStorageRecord;
 
 import java.util.Date;
 
@@ -81,7 +81,7 @@ class DatastoreProperties {
      * Makes AggregateId property from given {@link Message} value.
      */
     static void addAggregateIdProperty(Object aggregateId, Entity.Builder entity) {
-        final String propertyValue = Identifiers.idToString(aggregateId);
+        final String propertyValue = Stringifiers.idToString(aggregateId);
         entity.set(AGGREGATE_ID_PROPERTY_NAME, propertyValue);
     }
 
@@ -109,7 +109,7 @@ class DatastoreProperties {
      * Converts {@link org.spine3.base.Event}'s fields to a set of Properties, which are
      * ready to add to the Datastore entity.
      */
-    static void makeEventFieldProperties(EventStorageRecordOrBuilder event,
+    static void makeEventFieldProperties(EventStorageRecord event,
                                          Entity.Builder builder) {
         // We do not re-save timestamp
         // We do not re-save event type

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreRecordId.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreRecordId.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreRecordId.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreRecordId.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -20,23 +21,26 @@
  */
 package org.spine3.server.storage.datastore;
 
-import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyFactory;
-
 /**
- * Utility for generating Google Datastore {@link com.google.cloud.datastore.Key} instances.
+ * A wrapper type for the {@code String}-based record identifiers in the GAE Datastore.
  *
  * @author Alex Tymchenko
  */
-@SuppressWarnings("UtilityClass")
-class Keys {
+public class DatastoreRecordId {
 
-    private Keys() {}
+    // The wrapped identifier value.
+    private final String value;
 
-    static Key generateForKindWithName(DatastoreWrapper datastore, String kind, String keyName) {
-        final KeyFactory keyFactory = datastore.getKeyFactory(kind);
-        final Key key = keyFactory.newKey(keyName);
+    /**
+     * Creates a new {@code DatastoreRecordId} for the given {@code value}.
+     *
+     * @param value the identity as {@code String} to wrap into an identifier
+     */
+    DatastoreRecordId(String value) {
+        this.value = value;
+    }
 
-        return key;
+    public String getValue() {
+        return value;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -25,13 +25,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
 import org.spine3.server.aggregate.Aggregate;
+import org.spine3.server.aggregate.AggregateStorage;
+import org.spine3.server.command.CommandStorage;
 import org.spine3.server.entity.Entity;
-import org.spine3.server.storage.AggregateStorage;
-import org.spine3.server.storage.CommandStorage;
-import org.spine3.server.storage.EventStorage;
-import org.spine3.server.storage.ProjectionStorage;
+import org.spine3.server.event.EventStorage;
+import org.spine3.server.projection.ProjectionStorage;
+import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.RecordStorage;
-import org.spine3.server.storage.StandStorage;
 import org.spine3.server.storage.Storage;
 import org.spine3.server.storage.StorageFactory;
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -21,15 +21,13 @@
 package org.spine3.server.storage.datastore;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreOptions;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.entity.Entity;
 import org.spine3.server.storage.AggregateStorage;
 import org.spine3.server.storage.CommandStorage;
-import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.storage.EventStorage;
 import org.spine3.server.storage.ProjectionStorage;
 import org.spine3.server.storage.RecordStorage;
@@ -57,45 +55,32 @@ public class DatastoreStorageFactory implements StorageFactory {
 
     /**
      * Creates new instance of {@code DatastoreStorageFactory}.
-     * <p>
-     * <p>Same as calling {@link #newInstance(Datastore, boolean)} with {@code false} second argument.
-     *
-     * @param datastore the {@link Datastore} implementation to use
-     * @return new instance of the {@code DatastoreStorageFactory}.
-     * @see DatastoreOptions
-     */
-    @SuppressWarnings("WeakerAccess") // Part of API
-    public static DatastoreStorageFactory newInstance(Datastore datastore) {
-        return new DatastoreStorageFactory(datastore, false);
-    }
-
-    /**
-     * Creates new instance of {@code DatastoreStorageFactory}.
      *
      * @param datastore   the {@link Datastore} implementation to use
-     * @param multitenant shows if storage factory is configured to serve a multitenant application.
-     *                    The implementation does not yet support
-     *                    <a href="https://cloud.google.com/appengine/docs/java/multitenancy/multitenancy">Datastore recommended</a>
-     *                    way of creating multitenant apps.
+     * @param multitenant if storage factory is configured to serve a multitenant application.
+     *                    This implementation does not support
+     *                    <a href="https://cloud.google.com/appengine/docs/java/multitenancy/multitenancy">Datastore
+     *                    recommended</a> way of creating multitenant apps yet.
      *                    See {@link Storage#isMultitenant()}.
-     * @return creates new factory instance.
-     * @see DatastoreOptions
      */
-    @SuppressWarnings("WeakerAccess") // Part of API
-    public static DatastoreStorageFactory newInstance(Datastore datastore, boolean multitenant) {
-        return new DatastoreStorageFactory(datastore, multitenant);
-    }
-
-    // Overriding used for testing
     @SuppressWarnings({"OverridableMethodCallDuringObjectConstruction", "OverriddenMethodCallDuringObjectConstruction"})
-    DatastoreStorageFactory(Datastore datastore, boolean multitenant) {
+    public DatastoreStorageFactory(Datastore datastore, boolean multitenant) {
         this.multitenant = multitenant;
         initDatastoreWrapper(datastore);
     }
 
+    /**
+     * Creates new instance of non-multitenant {@code DatastoreStorageFactory}.
+     *
+     * @param datastore the {@link Datastore} implementation to use
+     */
+    public DatastoreStorageFactory(Datastore datastore) {
+        this(datastore, false);
+    }
+
     @VisibleForTesting
     protected void initDatastoreWrapper(Datastore datastore) {
-        checkState(this.getDatastore() == null, "Datastore is already init");
+        checkState(this.getDatastore() == null, "Datastore is already initialized");
         final DatastoreWrapper wrapped = DatastoreWrapper.wrap(datastore);
         this.setDatastore(wrapped);
     }
@@ -107,38 +92,53 @@ public class DatastoreStorageFactory implements StorageFactory {
 
     @Override
     public CommandStorage createCommandStorage() {
-        return DsCommandStorage.newInstance(getDatastore(), multitenant);
+        final DsCommandStorage result = new DsCommandStorage(getDatastore(), multitenant);
+        return result;
     }
 
     @Override
     public EventStorage createEventStorage() {
-        return DsEventStorage.newInstance(getDatastore(), multitenant);
+        final DsEventStorage result = new DsEventStorage(getDatastore(), multitenant);
+        return result;
     }
 
     @Override
     public StandStorage createStandStorage() {
         final DsRecordStorage<String> recordStorage
                 = (DsRecordStorage<String>) createRecordStorage(StandStorageRecord.class);
-        return DsStandStorage.newInstance(multitenant, recordStorage);
+        final DsStandStorage result = new DsStandStorage(recordStorage, multitenant);
+        return result;
     }
 
     @Override
     public <I> ProjectionStorage<I> createProjectionStorage(Class<? extends Entity<I, ?>> aClass) {
         final DsRecordStorage<I> entityStorage = (DsRecordStorage<I>) createRecordStorage(aClass);
-        final DsPropertyStorage propertyStorage = DsPropertyStorage.newInstance(getDatastore());
-        return DsProjectionStorage.newInstance(entityStorage, propertyStorage, aClass, multitenant);
+        final DsPropertyStorage propertyStorage = createPropertyStorage();
+        final DsProjectionStorage<I> result = new DsProjectionStorage<>(entityStorage,
+                                                                        propertyStorage,
+                                                                        aClass,
+                                                                        multitenant);
+        return result;
     }
 
     @Override
     public <I> RecordStorage<I> createRecordStorage(Class<? extends Entity<I, ?>> entityClass) {
         final Class<Message> messageClass = getGenericParameterType(entityClass, ENTITY_MESSAGE_TYPE_PARAMETER_INDEX);
-        final Descriptors.Descriptor descriptor = (Descriptors.Descriptor) getClassDescriptor(messageClass);
-        return DsRecordStorage.newInstance(descriptor, getDatastore(), multitenant);
+        final Descriptor descriptor = (Descriptor) getClassDescriptor(messageClass);
+        final DsRecordStorage<I> result = new DsRecordStorage<>(descriptor, getDatastore(), multitenant);
+        return result;
     }
 
     @Override
     public <I> AggregateStorage<I> createAggregateStorage(Class<? extends Aggregate<I, ?, ?>> ignored) {
-        return DsAggregateStorage.newInstance(getDatastore(), DsPropertyStorage.newInstance(getDatastore()), multitenant);
+        final DsPropertyStorage propertyStorage = createPropertyStorage();
+        final DsAggregateStorage<I> result = new DsAggregateStorage<>(getDatastore(), propertyStorage, multitenant);
+        return result;
+    }
+
+    protected DsPropertyStorage createPropertyStorage() {
+        final DsPropertyStorage propertyStorage = DsPropertyStorage.newInstance(getDatastore());
+        return propertyStorage;
     }
 
     @SuppressWarnings("ProhibitedExceptionDeclared")
@@ -155,19 +155,4 @@ public class DatastoreStorageFactory implements StorageFactory {
         this.datastore = datastore;
     }
 
-    /**
-     * {@link Entity} class used to declare stored type of {@link DsStandStorage}.
-     */
-    private static class StandStorageRecord extends Entity<String, EntityStorageRecord> {
-
-        /**
-         * Creates a new instance.
-         *
-         * @param id the ID for the new instance
-         * @throws IllegalArgumentException if the ID is not of one of the supported types for identifiers
-         */
-        private StandStorageRecord(String id) {
-            super(id);
-        }
-    }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -141,7 +141,6 @@ public class DatastoreStorageFactory implements StorageFactory {
         return propertyStorage;
     }
 
-    @SuppressWarnings("ProhibitedExceptionDeclared")
     @Override
     public void close() throws Exception {
         // NOP

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -104,8 +104,8 @@ public class DatastoreStorageFactory implements StorageFactory {
 
     @Override
     public StandStorage createStandStorage() {
-        final DsRecordStorage<String> recordStorage
-                = (DsRecordStorage<String>) createRecordStorage(StandStorageRecord.class);
+        final DsRecordStorage<DatastoreRecordId> recordStorage
+                = (DsRecordStorage<DatastoreRecordId>) createRecordStorage(StandStorageRecord.class);
         final DsStandStorage result = new DsStandStorage(recordStorage, multitenant);
         return result;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -124,7 +124,6 @@ class DatastoreWrapper {
      * @return the {@link Entity} or {@code null} in case of no results for the key given
      * @see DatastoreReader#get(Key)
      */
-    @SuppressWarnings("ReturnOfNull")
     Entity read(Key key) {
         return datastore.get(key);
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -59,14 +59,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
     private final DatastoreWrapper datastore;
     private final DsPropertyStorage propertyStorage;
 
-    static <I> DsAggregateStorage<I> newInstance(
-            DatastoreWrapper datastore,
-            DsPropertyStorage propertyStorage,
-            boolean multitenant) {
-        return new DsAggregateStorage<>(datastore, propertyStorage, multitenant);
-    }
-
-    private DsAggregateStorage(DatastoreWrapper datastore, DsPropertyStorage propertyStorage, boolean multitenant) {
+    public DsAggregateStorage(DatastoreWrapper datastore, DsPropertyStorage propertyStorage, boolean multitenant) {
         super(multitenant);
         this.datastore = datastore;
         this.propertyStorage = propertyStorage;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -24,6 +24,7 @@ import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StructuredQuery;
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Int32Value;
 import org.spine3.protobuf.Timestamps;
@@ -70,12 +71,15 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         checkNotClosed();
         checkNotNull(id);
 
-        final String datastoreId = generateDatastoreId(id);
-        final Int32Value count = propertyStorage.read(datastoreId);
-        if (count == null) {
-            return 0;
+        final DatastoreRecordId datastoreId = generateDatastoreId(id);
+        final Optional<Int32Value> count = propertyStorage.read(datastoreId);
+        final int countValue;
+        if (!count.isPresent()) {
+            countValue = 0;
+        } else {
+            countValue = count.get()
+                              .getValue();
         }
-        final int countValue = count.getValue();
         return countValue;
     }
 
@@ -84,7 +88,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         checkNotClosed();
         checkNotNull(id);
 
-        final String datastoreId = generateDatastoreId(id);
+        final DatastoreRecordId datastoreId = generateDatastoreId(id);
         propertyStorage.write(datastoreId, Int32Value.newBuilder()
                                                      .setValue(eventCount)
                                                      .build());
@@ -101,7 +105,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
             eventId = SNAPSHOT + stringId;
         }
 
-        final Key key = Keys.generateForKindWithName(datastore, KIND, eventId);
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, DatastoreIdentifiers.of(eventId));
         final Entity incompleteEntity = Entities.messageToEntity(record, key);
         final Entity.Builder builder = Entity.newBuilder(incompleteEntity);
         DatastoreProperties.addAggregateIdProperty(stringId, builder);
@@ -134,9 +138,38 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         return records.iterator();
     }
 
-    private String generateDatastoreId(I id) {
+    /**
+     * Generates an identifier of the Datastore record basing on the given {@code Aggregate} identifier.
+     *
+     * @param id an identifier of the {@code Aggregate}
+     * @return the Datastore record ID
+     */
+    protected DatastoreRecordId generateDatastoreId(I id) {
         final String stringId = idToString(id);
         final String datastoreId = EVENTS_AFTER_LAST_SNAPSHOT_PREFIX + stringId;
-        return datastoreId;
+        return DatastoreIdentifiers.of(datastoreId);
+    }
+
+    /**
+     * Provides an access to the GAE Datastore with an API, specific to the Spine framework.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the wrapped instance of Datastore
+     */
+    protected DatastoreWrapper getDatastore() {
+        return datastore;
+    }
+
+    /**
+     * Provides an access to the {@link DsPropertyStorage}.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the wrapped instance of Datastore
+     */
+    @SuppressWarnings("unused")     // Part of the API.
+    protected DsPropertyStorage getPropertyStorage() {
+        return propertyStorage;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -168,7 +168,6 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
      *
      * @return the wrapped instance of Datastore
      */
-    @SuppressWarnings("unused")     // Part of the API.
     protected DsPropertyStorage getPropertyStorage() {
         return propertyStorage;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -47,7 +47,8 @@ import static org.spine3.server.storage.datastore.DatastoreProperties.AGGREGATE_
  * @author Dmytro Dashenkov
  * @see DatastoreStorageFactory
  */
-class DsAggregateStorage<I> extends AggregateStorage<I> {
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsAggregateStorage<I> extends AggregateStorage<I> {
 
     private static final String EVENTS_AFTER_LAST_SNAPSHOT_PREFIX = "EVENTS_AFTER_SNAPSHOT_";
     private static final String SNAPSHOT = "SNAPSHOT";

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -29,8 +29,8 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.Int32Value;
 import org.spine3.protobuf.Timestamps;
 import org.spine3.protobuf.TypeUrl;
-import org.spine3.server.storage.AggregateStorage;
-import org.spine3.server.storage.AggregateStorageRecord;
+import org.spine3.server.aggregate.AggregateStorage;
+import org.spine3.server.aggregate.storage.AggregateStorageRecord;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -38,7 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spine3.base.Identifiers.idToString;
+import static org.spine3.base.Stringifiers.idToString;
 import static org.spine3.server.storage.datastore.DatastoreProperties.AGGREGATE_ID_PROPERTY_NAME;
 
 /**

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
@@ -161,4 +161,15 @@ public class DsCommandStorage extends CommandStorage {
                        .build();
         datastore.createOrUpdate(entity);
     }
+
+    /**
+     * Provides an access to the GAE Datastore with an API, specific to the Spine framework.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the wrapped instance of Datastore
+     */
+    protected DatastoreWrapper getDatastore() {
+        return datastore;
+    }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
@@ -73,11 +73,7 @@ public class DsCommandStorage extends CommandStorage {
         }
     };
 
-    static CommandStorage newInstance(DatastoreWrapper datastore, boolean multitenant) {
-        return new DsCommandStorage(datastore, multitenant);
-    }
-
-    private DsCommandStorage(DatastoreWrapper datastore, boolean multitenant) {
+    public DsCommandStorage(DatastoreWrapper datastore, boolean multitenant) {
         super(multitenant);
         this.datastore = datastore;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
@@ -30,8 +30,8 @@ import org.spine3.base.CommandStatus;
 import org.spine3.base.Error;
 import org.spine3.base.Failure;
 import org.spine3.protobuf.TypeUrl;
-import org.spine3.server.storage.CommandStorage;
-import org.spine3.server.storage.CommandStorageRecord;
+import org.spine3.server.command.CommandStorage;
+import org.spine3.server.command.storage.CommandStorageRecord;
 
 import javax.annotation.Nullable;
 import java.util.Collection;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
@@ -53,7 +53,8 @@ import static org.spine3.validate.Validate.checkNotDefault;
  * @author Dmytro Dashenkov
  * @see DatastoreStorageFactory
  */
-class DsCommandStorage extends CommandStorage {
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsCommandStorage extends CommandStorage {
 
     private static final TypeUrl TYPE_URL = TypeUrl.from(CommandStorageRecord.getDescriptor());
     private static final String KIND = CommandStorageRecord.class.getName();

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
@@ -40,7 +40,7 @@ import java.util.Iterator;
 import static com.google.cloud.datastore.StructuredQuery.Filter;
 import static com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spine3.base.Identifiers.idToString;
+import static org.spine3.server.storage.datastore.DatastoreIdentifiers.of;
 import static org.spine3.server.storage.datastore.DatastoreProperties.TIMESTAMP_NANOS_PROPERTY_NAME;
 import static org.spine3.server.storage.datastore.DatastoreProperties.TIMESTAMP_PROPERTY_NAME;
 import static org.spine3.server.storage.datastore.Entities.messageToEntity;
@@ -132,8 +132,7 @@ public class DsCommandStorage extends CommandStorage {
         checkNotClosed();
         checkNotDefault(commandId);
 
-        final String idString = idToString(commandId);
-        final Key key = Keys.generateForKindWithName(datastore, KIND, idString);
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, of(commandId));
         final Entity entity = datastore.read(key);
 
         if (entity == null) {
@@ -149,9 +148,7 @@ public class DsCommandStorage extends CommandStorage {
         checkNotDefault(commandId);
         checkNotDefault(record);
 
-        final String idString = idToString(commandId);
-
-        final Key key = Keys.generateForKindWithName(datastore, KIND, idString);
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, of(commandId));
 
         Entity entity = messageToEntity(record, key);
         entity = Entity.newBuilder(entity)

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -54,6 +54,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.spine3.base.Identifiers.idToString;
 import static org.spine3.server.storage.datastore.DatastoreProperties.TIMESTAMP_NANOS_PROPERTY_NAME;
+import static org.spine3.server.storage.datastore.DatastoreIdentifiers.of;
 import static org.spine3.server.storage.datastore.Entities.entityToMessage;
 import static org.spine3.server.storage.datastore.Entities.messageToEntity;
 
@@ -137,7 +138,7 @@ public class DsEventStorage extends EventStorage {
 
     @Override
     protected void writeRecord(EventStorageRecord record) {
-        final Key key = Keys.generateForKindWithName(datastore, KIND, record.getEventId());
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, of(record));
 
         final Entity entity = messageToEntity(record, key);
 
@@ -158,8 +159,7 @@ public class DsEventStorage extends EventStorage {
     @Nullable
     @Override
     protected EventStorageRecord readRecord(EventId eventId) {
-        final String idString = idToString(eventId);
-        final Key key = Keys.generateForKindWithName(datastore, KIND, idString);
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, of(eventId));
         final Entity response = datastore.read(key);
 
         if (response == null) {
@@ -282,9 +282,7 @@ public class DsEventStorage extends EventStorage {
             return true;
         }
 
-        private static boolean checkFields(
-                Message object,
-                @SuppressWarnings("TypeMayBeWeakened") /*BuilderOrType interface*/ FieldFilter filter) {
+        private static boolean checkFields(Message object, FieldFilter filter) {
             final String fieldPath = filter.getFieldPath();
             final String fieldName = fieldPath.substring(fieldPath.lastIndexOf('.') + 1);
             checkArgument(!Strings.isNullOrEmpty(fieldName), "Field filter " + filter.toString() + " is invalid");

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -170,6 +170,17 @@ public class DsEventStorage extends EventStorage {
         return result;
     }
 
+    /**
+     * Provides an access to the GAE Datastore with an API, specific to the Spine framework.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the wrapped instance of Datastore
+     */
+    protected DatastoreWrapper getDatastore() {
+        return datastore;
+    }
+
     private static class EventPredicate implements Predicate<EventStorageRecord> {
 
         private final Collection<EventFilter> eventFilters;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -120,7 +120,7 @@ public class DsEventStorage extends EventStorage {
         return toEventIterator(iterator);
     }
 
-    @SuppressWarnings({"MethodWithMoreThanThreeNegations", "ValueOfIncrementOrDecrementUsed", "DuplicateStringLiteralInspection"})
+    @SuppressWarnings({"ValueOfIncrementOrDecrementUsed", "DuplicateStringLiteralInspection"})
     private static Query toTimestampQuery(EventStreamQueryOrBuilder query) {
         final long lower = Timestamps.convertToNanos(query.getAfter());
         final long upper = query.hasBefore()
@@ -178,7 +178,6 @@ public class DsEventStorage extends EventStorage {
             this.eventFilters = eventFilters;
         }
 
-        @SuppressWarnings("MethodWithMoreThanThreeNegations")
         @Override
         public boolean apply(@Nullable EventStorageRecord event) {
             if (event == null) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -65,7 +65,8 @@ import static org.spine3.server.storage.datastore.Entities.messageToEntity;
  * @author Dmytro Dashenkov
  * @see DatastoreStorageFactory
  */
-class DsEventStorage extends EventStorage {
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsEventStorage extends EventStorage {
 
     private final DatastoreWrapper datastore;
     private static final String KIND = EventStorageRecord.class.getName();

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -126,7 +126,7 @@ public class DsEventStorage extends EventStorage {
         return toEventIterator(iterator);
     }
 
-    @SuppressWarnings({"ValueOfIncrementOrDecrementUsed", "DuplicateStringLiteralInspection"})
+    @SuppressWarnings("DuplicateStringLiteralInspection")
     private static Query toTimestampQuery(EventStreamQueryOrBuilder query) {
         final long lower = convertToNanos(query.getAfter());
         final long upper = query.hasBefore()

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -57,7 +57,6 @@ import static org.spine3.server.storage.datastore.DatastoreProperties.TIMESTAMP_
 import static org.spine3.server.storage.datastore.Entities.entityToMessage;
 import static org.spine3.server.storage.datastore.Entities.messageToEntity;
 
-
 /**
  * Storage for event records based on Google Cloud Datastore.
  *
@@ -97,11 +96,7 @@ public class DsEventStorage extends EventStorage {
         }
     };
 
-    static DsEventStorage newInstance(DatastoreWrapper datastore, boolean multitenant) {
-        return new DsEventStorage(datastore, multitenant);
-    }
-
-    private DsEventStorage(DatastoreWrapper datastore, boolean multitenant) {
+    public DsEventStorage(DatastoreWrapper datastore, boolean multitenant) {
         super(multitenant);
         this.datastore = datastore;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -36,7 +36,8 @@ import java.util.Map;
  *
  * @author Mikhail Mikhaylov
  */
-class DsProjectionStorage<I> extends ProjectionStorage<I> {
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsProjectionStorage<I> extends ProjectionStorage<I> {
 
     private static final String LAST_EVENT_TIMESTAMP_ID = "datastore_event_timestamp_";
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -46,17 +46,10 @@ public class DsProjectionStorage<I> extends ProjectionStorage<I> {
 
     private final String lastTimestampId;
 
-    static <I> DsProjectionStorage<I> newInstance(DsRecordStorage<I> entityStorage,
-                                                  DsPropertyStorage propertyStorage,
-                                                  Class<? extends Entity<I, ?>> projectionClass,
-                                                  boolean multitenant) {
-        return new DsProjectionStorage<>(entityStorage, propertyStorage, projectionClass, multitenant);
-    }
-
-    private DsProjectionStorage(DsRecordStorage<I> entityStorage,
-                                DsPropertyStorage propertyStorage,
-                                Class<? extends Entity<I, ?>> projectionClass,
-                                boolean multitenant) {
+    public DsProjectionStorage(DsRecordStorage<I> entityStorage,
+                               DsPropertyStorage propertyStorage,
+                               Class<? extends Entity<I, ?>> projectionClass,
+                               boolean multitenant) {
         super(multitenant);
         this.entityStorage = entityStorage;
         this.propertyStorage = propertyStorage;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -81,6 +81,11 @@ public class DsProjectionStorage<I> extends ProjectionStorage<I> {
         return entityStorage;
     }
 
+    @SuppressWarnings("unused")     // part of API
+    protected DsPropertyStorage getPropertyStorage() {
+        return propertyStorage;
+    }
+
     @Override
     protected Iterable<EntityStorageRecord> readMultipleRecords(Iterable<I> ids) {
         return getRecordStorage().readMultiple(ids);

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -81,7 +81,6 @@ public class DsProjectionStorage<I> extends ProjectionStorage<I> {
         return entityStorage;
     }
 
-    @SuppressWarnings("unused")     // part of API
     protected DsPropertyStorage getPropertyStorage() {
         return propertyStorage;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -24,8 +24,8 @@ import com.google.common.base.Optional;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import org.spine3.server.entity.Entity;
+import org.spine3.server.projection.ProjectionStorage;
 import org.spine3.server.storage.EntityStorageRecord;
-import org.spine3.server.storage.ProjectionStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.validate.Validate;
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
@@ -75,4 +75,15 @@ public class DsPropertyStorage {
         final V result = AnyPacker.unpack(anyResult);
         return Optional.fromNullable(result);
     }
+
+    /**
+     * Provides an access to the GAE Datastore with an API, specific to the Spine framework.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the wrapped instance of Datastore
+     */
+    protected DatastoreWrapper getDatastore() {
+        return datastore;
+    }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
@@ -38,7 +38,8 @@ import static org.spine3.server.storage.datastore.Entities.messageToEntity;
  *
  * @author Mikhail Mikhaylov
  */
-class DsPropertyStorage {
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsPropertyStorage {
 
     private static final TypeUrl ANY_TYPE_URL = TypeUrl.from(Any.getDescriptor());
     private static final String KIND = Any.class.getName();

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -177,7 +177,6 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return queryAll(mapper, null, FieldMask.getDefaultInstance());
     }
 
-    @SuppressWarnings("WeakerAccess")       // A part of API.
     public Map<?, EntityStorageRecord> readAllByType(final TypeUrl typeUrl, final FieldMask fieldMask) {
         final Function<Entity, IdRecordPair<I>> mapper = new Function<Entity, IdRecordPair<I>>() {
             @Nullable
@@ -207,7 +206,6 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return queryAll(mapper, typeUrl, FieldMask.getDefaultInstance());
     }
 
-    @SuppressWarnings("WeakerAccess")       // A part of API.
     public Map<?, EntityStorageRecord> readAllByType(final TypeUrl typeUrl) {
         final Function<Entity, IdRecordPair<I>> mapper = new Function<Entity, IdRecordPair<I>>() {
             @Nullable

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -177,6 +177,29 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return queryAll(mapper, null, FieldMask.getDefaultInstance());
     }
 
+    /**
+     * Provides an access to the GAE Datastore with an API, specific to the Spine framework.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the wrapped instance of Datastore
+     */
+    protected DatastoreWrapper getDatastore() {
+        return datastore;
+    }
+
+    /**
+     * Obtains the {@link TypeUrl} of the messages to save to this store.
+     *
+     * <p>Allows the customization of the storage behavior in descendants.
+     *
+     * @return the {@code TyprUrl} of the stored messages
+     */
+    @SuppressWarnings("unused")     // part of API.
+    protected TypeUrl getTypeUrl() {
+        return typeUrl;
+    }
+
     public Map<?, EntityStorageRecord> readAllByType(final TypeUrl typeUrl, final FieldMask fieldMask) {
         final Function<Entity, IdRecordPair<I>> mapper = new Function<Entity, IdRecordPair<I>>() {
             @Nullable

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -70,12 +70,6 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
             "Note: custom conversion is not supported. " +
             "See org.spine3.base.Identifiers#idToString.";
 
-    static <I> DsRecordStorage<I> newInstance(Descriptor descriptor,
-                                              DatastoreWrapper datastore,
-                                              boolean multitenant) {
-        return new DsRecordStorage<>(descriptor, datastore, multitenant);
-    }
-
     private static final Function<Entity, EntityStorageRecord> recordFromEntity
             = new Function<Entity, EntityStorageRecord>() {
         @Nullable
@@ -96,7 +90,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
      * @param descriptor the descriptor of the type of messages to save to the storage
      * @param datastore  the Datastore implementation to use
      */
-    private DsRecordStorage(Descriptor descriptor, DatastoreWrapper datastore, boolean multitenant) {
+    public DsRecordStorage(Descriptor descriptor, DatastoreWrapper datastore, boolean multitenant) {
         super(multitenant);
         this.typeUrl = TypeUrl.from(descriptor);
         this.datastore = datastore;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -55,7 +55,8 @@ import static com.google.common.base.Preconditions.checkState;
  * @author Dmytro Dashenkov
  * @see DatastoreStorageFactory
  */
-class DsRecordStorage<I> extends RecordStorage<I> {
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsRecordStorage<I> extends RecordStorage<I> {
 
     private final DatastoreWrapper datastore;
     private final TypeUrl typeUrl;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -47,6 +47,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static org.spine3.server.storage.datastore.DatastoreIdentifiers.ofEntityId;
 
 /**
  * {@link RecordStorage} implementation based on Google App Engine Datastore.
@@ -99,8 +100,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     @Nullable
     @Override
     protected EntityStorageRecord readRecord(I id) {
-        final String idString = IdTransformer.idToString(id);
-        final Key key = Keys.generateForKindWithName(datastore, KIND, idString);
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, ofEntityId(id));
         final Entity response = datastore.read(key);
 
         if (response == null) {
@@ -242,8 +242,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
         final Collection<Key> keys = new LinkedList<>();
         for (I id : ids) {
-            final String idString = IdTransformer.idToString(id);
-            final Key key = Keys.generateForKindWithName(datastore, KIND, idString);
+            final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, ofEntityId(id));
             keys.add(key);
         }
 
@@ -291,8 +290,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         final String valueTypeUrl = entityStorageRecord.getState()
                                                        .getTypeUrl();
 
-        final String idString = IdTransformer.idToString(id);
-        final Key key = Keys.generateForKindWithName(datastore, KIND, idString);
+        final Key key = DatastoreIdentifiers.keyFor(datastore, KIND, ofEntityId(id));
         final Entity incompleteEntity = Entities.messageToEntity(entityStorageRecord, key);
         final Entity.Builder entity = Entity.newBuilder(incompleteEntity);
         entity.set(VERSION_KEY, entityStorageRecord.getVersion());

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -56,7 +56,6 @@ import static org.spine3.server.storage.datastore.DatastoreIdentifiers.ofEntityI
  * @author Dmytro Dashenkov
  * @see DatastoreStorageFactory
  */
-@SuppressWarnings("WeakerAccess")   // Part of API
 public class DsRecordStorage<I> extends RecordStorage<I> {
 
     private final DatastoreWrapper datastore;
@@ -195,7 +194,6 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
      *
      * @return the {@code TyprUrl} of the stored messages
      */
-    @SuppressWarnings("unused")     // part of API.
     protected TypeUrl getTypeUrl() {
         return typeUrl;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
@@ -30,8 +30,8 @@ import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import org.spine3.protobuf.TypeUrl;
 import org.spine3.server.stand.AggregateStateId;
+import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.EntityStorageRecord;
-import org.spine3.server.storage.StandStorage;
 
 import javax.annotation.Nullable;
 import java.util.Collection;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
@@ -46,7 +46,9 @@ import static com.google.common.base.Preconditions.checkState;
  *
  * @author Dmytro Dashenkov
  */
-class DsStandStorage extends StandStorage {
+
+@SuppressWarnings("WeakerAccess")   // Part of API
+public class DsStandStorage extends StandStorage {
 
     private static final Function<AggregateStateId, String> ID_TRANSFORMER = new Function<AggregateStateId, String>() {
         @Override

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
@@ -61,11 +61,7 @@ public class DsStandStorage extends StandStorage {
 
     private final DsRecordStorage<String> recordStorage;
 
-    static StandStorage newInstance(boolean multitenant, DsRecordStorage<String> recordStorage) {
-        return new DsStandStorage(multitenant, recordStorage);
-    }
-
-    private DsStandStorage(boolean multitenant, DsRecordStorage<String> recordStorage) {
+    public DsStandStorage(DsRecordStorage<String> recordStorage, boolean multitenant) {
         super(multitenant);
         this.recordStorage = recordStorage;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
@@ -65,7 +65,6 @@ class Entities {
      * @param <M>    required message type
      * @return message contained in the {@link Entity}
      */
-    @SuppressWarnings("unchecked")
     static <M extends Message> M entityToMessage(@Nullable Entity entity, TypeUrl type) {
         if (entity == null) {
             return defaultMessage(type);
@@ -93,7 +92,6 @@ class Entities {
      * @param <M>      required message type
      * @return message contained in the {@link Entity}
      */
-    @SuppressWarnings("unchecked")
     static <M extends Message> List<M> entitiesToMessages(Collection<Entity> entities, TypeUrl type) {
         if (entities.isEmpty()) {
             return Collections.emptyList();

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/IdTransformer.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/IdTransformer.java
@@ -158,7 +158,6 @@ class IdTransformer {
         return id;
     }
 
-    @SuppressWarnings("ConstantConditions") // Nullable argument parametrizedClass
     private static <I> Class<I> getIdClass(String stringId, @Nullable Class parametrizedClass) {
         if (parametrizedClass == null) {
             return tryAllSupportedClasses(stringId);

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/StandStorageRecord.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/StandStorageRecord.java
@@ -27,6 +27,7 @@ import org.spine3.server.storage.EntityStorageRecord;
  *
  * @author Dmytro Dashenkov
  */
+@SuppressWarnings("WeakerAccess")   // Part of API.
 public class StandStorageRecord extends Entity<DatastoreRecordId, EntityStorageRecord> {
 
     /**

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/StandStorageRecord.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/StandStorageRecord.java
@@ -27,7 +27,7 @@ import org.spine3.server.storage.EntityStorageRecord;
  *
  * @author Dmytro Dashenkov
  */
-public class StandStorageRecord extends Entity<String, EntityStorageRecord> {
+public class StandStorageRecord extends Entity<DatastoreRecordId, EntityStorageRecord> {
 
     /**
      * Creates a new instance.
@@ -35,7 +35,7 @@ public class StandStorageRecord extends Entity<String, EntityStorageRecord> {
      * @param id the ID for the new instance
      * @throws IllegalArgumentException if the ID is not of one of the supported types for identifiers
      */
-    private StandStorageRecord(String id) {
+    private StandStorageRecord(DatastoreRecordId id) {
         super(id);
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/StandStorageRecord.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/StandStorageRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.spine3.server.storage.datastore;
+
+import org.spine3.server.entity.Entity;
+import org.spine3.server.storage.EntityStorageRecord;
+
+/**
+ * A type of entity record, used to store {@link Entity} state in the {@link DsStandStorage}.
+ *
+ * @author Dmytro Dashenkov
+ */
+public class StandStorageRecord extends Entity<String, EntityStorageRecord> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id the ID for the new instance
+     * @throws IllegalArgumentException if the ID is not of one of the supported types for identifiers
+     */
+    private StandStorageRecord(String id) {
+        super(id);
+    }
+}

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreIdentifiersShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreIdentifiersShould.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -16,27 +17,39 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  */
 package org.spine3.server.storage.datastore;
 
-import org.spine3.server.entity.Entity;
-import org.spine3.server.storage.EntityStorageRecord;
+import org.junit.Test;
+import org.spine3.base.Identifiers;
+import org.spine3.test.Tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
- * A type of entity record, used to store {@link Entity} state in the {@link DsStandStorage}.
- *
- * @author Dmytro Dashenkov
+ * @author Alex Tymchenko
  */
-@SuppressWarnings("WeakerAccess")   // Part of API.
-public class StandStorageRecord extends Entity<DatastoreRecordId, EntityStorageRecord> {
+public class DatastoreIdentifiersShould {
 
-    /**
-     * Creates a new instance.
-     *
-     * @param id the ID for the new instance
-     * @throws IllegalArgumentException if the ID is not of one of the supported types for identifiers
-     */
-    protected StandStorageRecord(DatastoreRecordId id) {
-        super(id);
+    @Test
+    public void have_private_constructor() {
+        assertTrue(Tests.hasPrivateUtilityConstructor(DatastoreIdentifiers.class));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void not_accept_empty_String_as_identifier_source() {
+        DatastoreIdentifiers.of("");
+    }
+
+    @Test
+    public void wrap_non_empty_String_into_record_identifier() {
+        final String idAsString = Identifiers.newUuid();
+        final DatastoreRecordId recordId = DatastoreIdentifiers.of(idAsString);
+
+        assertNotNull(recordId);
+        assertEquals(idAsString, recordId.getValue());
     }
 }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreIdentifiersShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreIdentifiersShould.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastorePropertiesShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastorePropertiesShould.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
@@ -39,16 +39,16 @@ import static org.junit.Assert.assertTrue;
 public class DatastoreStorageFactoryShould {
 
     private static final DatastoreOptions DUMMY_OPTIONS = DatastoreOptions.newBuilder()
-            .setProjectId("dummy-dataset")
-            .build();
+                                                                          .setProjectId("dummy-dataset")
+                                                                          .build();
 
     private static final Datastore DATASTORE = DUMMY_OPTIONS.getService();
 
-    private static final StorageFactory FACTORY = DatastoreStorageFactory.newInstance(DATASTORE);
+    private static final StorageFactory FACTORY = new DatastoreStorageFactory(DATASTORE);
 
     @Test
     public void create_multitenant_storages() throws Exception {
-        final StorageFactory factory = DatastoreStorageFactory.newInstance(DATASTORE, true);
+        final StorageFactory factory = new DatastoreStorageFactory(DATASTORE, true);
         assertTrue(factory.isMultitenant());
         final CommandStorage storage = factory.createCommandStorage();
         assertTrue(storage.isMultitenant());

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
@@ -24,11 +24,11 @@ import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.protobuf.StringValue;
 import org.junit.Test;
+import org.spine3.server.aggregate.AggregateStorage;
+import org.spine3.server.aggregate.storage.AggregateStorageRecord;
+import org.spine3.server.command.CommandStorage;
 import org.spine3.server.entity.Entity;
-import org.spine3.server.storage.AggregateStorage;
-import org.spine3.server.storage.AggregateStorageRecord;
-import org.spine3.server.storage.CommandStorage;
-import org.spine3.server.storage.EventStorage;
+import org.spine3.server.event.EventStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.StorageFactory;
 

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsAggregateStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsAggregateStorageShould.java
@@ -24,6 +24,7 @@ import com.google.protobuf.Message;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.server.aggregate.Aggregate;
@@ -31,6 +32,8 @@ import org.spine3.server.aggregate.AggregateStorage;
 import org.spine3.server.aggregate.AggregateStorageShould;
 import org.spine3.test.aggregate.ProjectId;
 import org.spine3.test.storage.Project;
+
+import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class DsAggregateStorageShould extends AggregateStorageShould {
@@ -79,6 +82,20 @@ public class DsAggregateStorageShould extends AggregateStorageShould {
         final AggregateStorage storage = getStorage(TestAggregateWithIdLong.class);
         final long id = 42L;
         this.writeAndReadEventTest(id, storage);
+    }
+
+    @Test
+    public void provide_access_to_DatastoreWrapper_for_extensibility() {
+        final DsAggregateStorage<ProjectId> storage = (DsAggregateStorage<ProjectId>) getStorage();
+        final DatastoreWrapper datastore = storage.getDatastore();
+        assertNotNull(datastore);
+    }
+
+    @Test
+    public void provide_access_to_PropertyStorage_for_extensibility() {
+        final DsAggregateStorage<ProjectId> storage = (DsAggregateStorage<ProjectId>) getStorage();
+        final DsPropertyStorage propertyStorage = storage.getPropertyStorage();
+        assertNotNull(propertyStorage);
     }
 
     private static class TestAggregateWithIdLong extends Aggregate<Long, Project, org.spine3.test.storage.Project.Builder> {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsAggregateStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsAggregateStorageShould.java
@@ -27,10 +27,10 @@ import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.server.aggregate.Aggregate;
-import org.spine3.server.storage.AggregateStorage;
-import org.spine3.server.storage.AggregateStorageShould;
+import org.spine3.server.aggregate.AggregateStorage;
+import org.spine3.server.aggregate.AggregateStorageShould;
+import org.spine3.test.aggregate.ProjectId;
 import org.spine3.test.storage.Project;
-import org.spine3.test.storage.ProjectId;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class DsAggregateStorageShould extends AggregateStorageShould {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsCommandStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsCommandStorageShould.java
@@ -23,8 +23,8 @@ package org.spine3.server.storage.datastore;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.spine3.server.storage.CommandStorage;
-import org.spine3.server.storage.CommandStorageShould;
+import org.spine3.server.command.CommandStorage;
+import org.spine3.server.command.CommandStorageShould;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class DsCommandStorageShould extends CommandStorageShould {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsEventStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsEventStorageShould.java
@@ -23,8 +23,8 @@ package org.spine3.server.storage.datastore;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.spine3.server.storage.EventStorage;
-import org.spine3.server.storage.EventStorageShould;
+import org.spine3.server.event.EventStorage;
+import org.spine3.server.event.EventStorageShould;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class DsEventStorageShould extends EventStorageShould {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsEventStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsEventStorageShould.java
@@ -23,8 +23,11 @@ package org.spine3.server.storage.datastore;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.spine3.server.event.EventStorage;
 import org.spine3.server.event.EventStorageShould;
+
+import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class DsEventStorageShould extends EventStorageShould {
@@ -55,5 +58,12 @@ public class DsEventStorageShould extends EventStorageShould {
     @AfterClass
     public static void tearDownClass() {
         DATASTORE_FACTORY.tearDown();
+    }
+
+    @Test
+    public void provide_access_to_DatastoreWrapper_for_extensibility() {
+        final DsEventStorage storage = (DsEventStorage) getStorage();
+        final DatastoreWrapper datastore = storage.getDatastore();
+        assertNotNull(datastore);
     }
 }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsProjectionStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsProjectionStorageShould.java
@@ -21,18 +21,21 @@
 package org.spine3.server.storage.datastore;
 
 import org.junit.After;
+import org.junit.Test;
 import org.spine3.base.Identifiers;
 import org.spine3.server.projection.Projection;
 import org.spine3.server.projection.ProjectionStorage;
 import org.spine3.server.projection.ProjectionStorageShould;
 import org.spine3.test.projection.Project;
 
+import static org.junit.Assert.assertNotNull;
+
 /**
  * @author Mikhail Mikhaylov
  */
-@SuppressWarnings("RefusedBequest") // Overrides several methods as NoOps
 public class DsProjectionStorageShould extends ProjectionStorageShould<String> {
-    private static final TestDatastoreStorageFactory DATASTORE_FACTORY = TestDatastoreStorageFactory.getDefaultInstance();
+    private static final TestDatastoreStorageFactory DATASTORE_FACTORY =
+            TestDatastoreStorageFactory.getDefaultInstance();
 
     @After
     public void tearDownTest() {
@@ -47,6 +50,13 @@ public class DsProjectionStorageShould extends ProjectionStorageShould<String> {
     @Override
     protected String newId() {
         return Identifiers.newUuid();
+    }
+
+    @Test
+    public void provide_access_to_PropertyStorage_for_extensibility() {
+        final DsProjectionStorage<String> storage = (DsProjectionStorage<String>) getStorage();
+        final DsPropertyStorage propertyStorage = storage.getPropertyStorage();
+        assertNotNull(propertyStorage);
     }
 
     private static class TestProjection extends Projection<String, Project> {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsProjectionStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsProjectionStorageShould.java
@@ -23,8 +23,8 @@ package org.spine3.server.storage.datastore;
 import org.junit.After;
 import org.spine3.base.Identifiers;
 import org.spine3.server.projection.Projection;
-import org.spine3.server.storage.ProjectionStorage;
-import org.spine3.server.storage.ProjectionStorageShould;
+import org.spine3.server.projection.ProjectionStorage;
+import org.spine3.server.projection.ProjectionStorageShould;
 import org.spine3.test.projection.Project;
 
 /**

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsPropertyStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsPropertyStorageShould.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsPropertyStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsPropertyStorageShould.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -16,48 +17,30 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  */
-
 package org.spine3.server.storage.datastore;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.spine3.server.command.CommandStorage;
-import org.spine3.server.command.CommandStorageShould;
 
 import static org.junit.Assert.assertNotNull;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
-public class DsCommandStorageShould extends CommandStorageShould {
-
-    private static final TestDatastoreStorageFactory DATASTORE_FACTORY = TestDatastoreStorageFactory.getDefaultInstance();
-
-    @BeforeClass
-    public static void setUpClass() {
-        DATASTORE_FACTORY.setUp();
-    }
-
-    @After
-    public void tearDownTest() {
-        DATASTORE_FACTORY.clear();
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-        DATASTORE_FACTORY.tearDown();
-    }
-
-    @Override
-    protected CommandStorage getStorage() {
-        return DATASTORE_FACTORY.createCommandStorage();
-    }
+/**
+ * @author Alex Tymchenko
+ */
+public class DsPropertyStorageShould {
+    private static final TestDatastoreStorageFactory DATASTORE_FACTORY =
+            TestDatastoreStorageFactory.getDefaultInstance();
 
     @Test
     public void provide_access_to_DatastoreWrapper_for_extensibility() {
-        final DsCommandStorage storage = (DsCommandStorage) getStorage();
+        final DsPropertyStorage storage = getStorage();
         final DatastoreWrapper datastore = storage.getDatastore();
         assertNotNull(datastore);
     }
+
+    private static DsPropertyStorage getStorage() {
+        return DATASTORE_FACTORY.createPropertyStorage();
+    }
+
 }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsRecordStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsRecordStorageShould.java
@@ -23,7 +23,9 @@ package org.spine3.server.storage.datastore;
 import com.google.protobuf.Message;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.spine3.base.Identifiers;
+import org.spine3.protobuf.TypeUrl;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.storage.AbstractStorage;
 import org.spine3.server.storage.EntityStorageRecord;
@@ -31,6 +33,9 @@ import org.spine3.server.storage.RecordStorageShould;
 import org.spine3.test.storage.Project;
 import org.spine3.test.storage.ProjectId;
 import org.spine3.test.storage.Task;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Dmytro Dashenkov
@@ -48,6 +53,23 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId> {
     @After
     public void tearDown() throws Exception {
         LOCAL_DATASTORE_STORAGE_FACTORY.tearDown();
+    }
+
+    @Test
+    public void provide_access_to_DatastoreWrapper_for_extensibility() {
+        final DsRecordStorage<ProjectId> storage = getStorage();
+        final DatastoreWrapper datastore = storage.getDatastore();
+        assertNotNull(datastore);
+    }
+
+    @Test
+    public void provide_access_to_TypeUrl_for_extensibility() {
+        final DsRecordStorage<ProjectId> storage = getStorage();
+        final TypeUrl typeUrl = storage.getTypeUrl();
+        assertNotNull(typeUrl);
+
+        // According to the `TestAggregate` declaration.
+        assertEquals(TypeUrl.of(Project.class), typeUrl);
     }
 
     @Override
@@ -70,8 +92,8 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId> {
     @Override
     protected ProjectId newId() {
         final ProjectId projectId = ProjectId.newBuilder()
-                .setId(Identifiers.newUuid())
-                .build();
+                                             .setId(Identifiers.newUuid())
+                                             .build();
         return projectId;
     }
 

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsStandStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsStandStorageShould.java
@@ -23,9 +23,9 @@ package org.spine3.server.storage.datastore;
 import org.junit.After;
 import org.junit.Before;
 import org.spine3.server.stand.AggregateStateId;
+import org.spine3.server.stand.StandStorageShould;
 import org.spine3.server.storage.AbstractStorage;
 import org.spine3.server.storage.EntityStorageRecord;
-import org.spine3.server.storage.StandStorageShould;
 
 /**
  * @author Dmytro Dashenkov

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/StandStorageRecordShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/StandStorageRecordShould.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/StandStorageRecordShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/StandStorageRecordShould.java
@@ -1,0 +1,83 @@
+/*
+ *
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package org.spine3.server.storage.datastore;
+
+import org.junit.Test;
+import org.spine3.base.Identifiers;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class StandStorageRecordShould {
+
+    @Test
+    public void have_protected_constructor_for_extension() {
+        final DatastoreRecordId someRecordId = DatastoreIdentifiers.of(Identifiers.newUuid());
+        final boolean matches = hasProtectedConstructorWithSingleParam(
+                StandStorageRecord.class, someRecordId);
+        assertTrue(matches);
+    }
+
+    /**
+     * Checks that the given {@code clazz} has the protected constructor with the
+     * single parameter of the specified type.
+     *
+     * <p>This method invokes this constructor passing the given {@code constructorArg}
+     * to include it into the coverage report.
+     *
+     * @param clazz          the class to check
+     * @param constructorArg the constructor argument of the expected type
+     * @param <I>            the expected type of the constructor argument
+     * @return {@code true} if the protected constructor is present, {@code false} otherwise
+     */
+    public static <I> boolean hasProtectedConstructorWithSingleParam(
+            Class<?> clazz, I constructorArg) {
+        final Constructor constructor;
+        try {
+            constructor = clazz.getDeclaredConstructor(constructorArg.getClass());
+        } catch (NoSuchMethodException ignored) {
+            return false;
+        }
+
+        if (!Modifier.isProtected(constructor.getModifiers())) {
+            return false;
+        }
+
+        final Class[] parameterTypes = constructor.getParameterTypes();
+        if (parameterTypes.length != 1) {
+            return false;
+        }
+
+        constructor.setAccessible(true);
+        try {
+            constructor.newInstance(constructorArg);
+        } catch (Exception ignored) {
+            return true;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Before this PR there was no convenient way to override the default behavior of the `..Storage` implementations.

Summary of changes:
* constructor and key methods/properties are exposed either as `public` or `protected` instead of `private` as before;
* the "extensibility" is covered with tests;
* `gae-java` was updated to the Spine `0.7.9-SNAPSHOT`;
* the own version of the `gae-java` has been increased to `0.7.9-SNAPSHOT` as well.