### PR TITLE
Fix bulk read

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 project.ext {
-    SPINE_VERSION = '0.7.9-SNAPSHOT'
-    GAE_JAVA_VERSION = "0.7.9-SNAPSHOT"
+    SPINE_VERSION = '0.8.0'
+    GAE_JAVA_VERSION = "0.8.0"
     PROTOBUF_VERSION = '3.1.0'
     SLf4J_VERSION = "1.7.21"
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}"

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -123,6 +123,16 @@ class DatastoreWrapper {
     }
 
     /**
+     * Writes the {@link Entity entities} to the Datastore or modifies the existing ones.
+     *
+     * @param entities the {@link Entity Entities} to write or update
+     * @see DatastoreWrapper#createOrUpdate(Entity)
+     */
+    public void createOrUpdate(Entity... entities) {
+        actor.put(entities);
+    }
+
+    /**
      * Retrieves an {@link Entity} with the given key from the Datastore.
      *
      * @param key {@link Key} to search for

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -256,14 +256,17 @@ class DatastoreWrapper {
         if (keysArray.length > MAX_KEYS_PER_WRITE_REQUEST) {
             int start = 0;
             int end = MAX_KEYS_PER_WRITE_REQUEST;
-            while (end < keysArray.length) {
+            while (true) {
                 final int length = end - start;
+                if (length <= 0) {
+                    return;
+                }
                 final Key[] keysSubarray = new Key[length];
                 System.arraycopy(keysArray, start, keysSubarray, 0, keysSubarray.length);
                 delete(keysSubarray);
 
                 start = end;
-                end = min(end + MAX_KEYS_PER_WRITE_REQUEST, keysArray.length - end);
+                end = min(MAX_KEYS_PER_WRITE_REQUEST, keysArray.length - end);
             }
         } else {
             delete(keysArray);

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -252,7 +252,10 @@ class DatastoreWrapper {
 
         final Key[] keysArray = new Key[keys.size()];
         keys.toArray(keysArray);
+        dropTableInternal(keysArray);
+    }
 
+    void dropTableInternal(Key[] keysArray) {
         if (keysArray.length > MAX_KEYS_PER_WRITE_REQUEST) {
             int start = 0;
             int end = MAX_KEYS_PER_WRITE_REQUEST;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -165,10 +165,10 @@ public class DatastoreWrapper {
 
     /**
      * Queries the Datastore with the given arguments.
-     * <p>
+     *
      * <p>As the Datastore may return a partial result set for {@link EntityQuery}, {@link KeyQuery}
      * and {@link ProjectionEntityQuery}, it is required to repeat a query with the adjusted cursor position.
-     * <p>
+     *
      * <p>Therefore, an execution of this method may in fact result in several queries to the Datastore instance.
      *
      * @param query {@link Query} to execute upon the Datastore
@@ -279,7 +279,7 @@ public class DatastoreWrapper {
 
     /**
      * Starts a transaction.
-     * <p>
+     *
      * <p>After this method is called, all {@code Entity} modifications performed through this instance of
      * {@code DatastoreWrapper} become transactional. This behaviour lasts until either {@link #commitTransaction()} or
      * {@link #rollbackTransaction()} is called.
@@ -297,9 +297,9 @@ public class DatastoreWrapper {
 
     /**
      * Commits a transaction.
-     * <p>
+     *
      * <p>Upon the method call, all the modifications within the active transaction are applied.
-     * <p>
+     *
      * <p>All next operations become non-transactional until {@link #startTransaction()} is called.
      *
      * @throws IllegalStateException if no transaction is started on this instance of {@code DatastoreWrapper}
@@ -315,9 +315,9 @@ public class DatastoreWrapper {
 
     /**
      * Rollbacks a transaction.
-     * <p>
+     *
      * <p>Upon the method call, all the modifications within the active transaction canceled permanently.
-     * <p>
+     *
      * <p>After this method execution is over, all the further modifications made through the current instance of
      * {@code DatastoreWrapper} become non-transactional.
      *
@@ -345,7 +345,7 @@ public class DatastoreWrapper {
 
     /**
      * Retrieves an instance of {@link KeyFactory} unique for given Kind of data.
-     * <p>
+     *
      * <p>Retrieved instances are the same across all instances of {@code DatastoreWrapper}.
      *
      * @param kind kind of {@link Entity} to generate keys for

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -152,7 +152,7 @@ class DatastoreWrapper {
      * @see DatastoreReader#fetch(Key...)
      */
     public List<Entity> read(Iterable<Key> keys) {
-        final List<Key> keysList = Lists.newLinkedList(keys);
+        final List<Key> keysList = newLinkedList(keys);
         final List<Entity> result;
         if (keysList.size() <= MAX_KEYS_PER_READ_REQUEST) {
             result = readSmallBulk(keysList);

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -386,7 +386,7 @@ public class DatastoreWrapper {
         for (int i = 0; i < pageCount; i++) {
             final List<Key> keysPage = keys.subList(lowerBound, higherBound);
 
-            final List<Entity> page = Lists.newArrayList(datastore.get(keys));
+            final List<Entity> page = Lists.newArrayList(datastore.get(keysPage));
             result.addAll(page);
 
             keysLeft -= keysPage.size();

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -287,8 +287,7 @@ public class DatastoreWrapper {
      * @throws IllegalStateException if a transaction is already started on this instance of {@code DatastoreWrapper}
      * @see #isTransactionActive()
      */
-    @SuppressWarnings("WeakerAccess")
-    // Part of API
+    @SuppressWarnings("WeakerAccess") // Part of API
     public void startTransaction() throws IllegalStateException {
         checkState(!isTransactionActive(), NOT_ACTIVE_TRANSACTION_CONDITION_MESSAGE);
         activeTransaction = datastore.newTransaction();
@@ -324,8 +323,7 @@ public class DatastoreWrapper {
      * @throws IllegalStateException if no transaction is active for the current instance of {@code DatastoreWrapper}
      * @see #isTransactionActive()
      */
-    @SuppressWarnings("WeakerAccess")
-    // Part of API
+    @SuppressWarnings("WeakerAccess") // Part of API
     public void rollbackTransaction() throws IllegalStateException {
         checkState(isTransactionActive(), ACTIVE_TRANSACTION_CONDITION_MESSAGE);
         activeTransaction.rollback();
@@ -337,8 +335,7 @@ public class DatastoreWrapper {
      *
      * @return {@code true} if there is an active transaction, {@code false} otherwise
      */
-    @SuppressWarnings("WeakerAccess")
-    // Part of API
+    @SuppressWarnings("WeakerAccess") // Part of API
     public boolean isTransactionActive() {
         return activeTransaction != null && activeTransaction.isActive();
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -73,7 +73,7 @@ public class DatastoreWrapper {
     private Transaction activeTransaction;
     private DatastoreReaderWriter actor;
 
-    DatastoreWrapper(Datastore datastore) {
+    protected DatastoreWrapper(Datastore datastore) {
         this.datastore = datastore;
         this.actor = datastore;
     }
@@ -84,7 +84,8 @@ public class DatastoreWrapper {
      * @param datastore {@link Datastore} to wrap
      * @return new instance of {@code DatastoreWrapper}
      */
-    static DatastoreWrapper wrap(Datastore datastore) {
+    @SuppressWarnings("WeakerAccess") // Part of API
+    protected static DatastoreWrapper wrap(Datastore datastore) {
         return new DatastoreWrapper(datastore);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -59,7 +59,7 @@ import static java.lang.Math.min;
  *
  * @author Dmytro Dashenkov
  */
-class DatastoreWrapper {
+public class DatastoreWrapper {
 
     private static final String ACTIVE_TRANSACTION_CONDITION_MESSAGE = "Transaction should be active.";
     private static final String NOT_ACTIVE_TRANSACTION_CONDITION_MESSAGE = "Transaction should NOT be active.";

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -55,6 +55,7 @@ import static java.lang.Math.min;
 
 /**
  * Represents a wrapper above GAE {@link Datastore}.
+ *
  * <p>Provides API for Datastore to be used in storages.
  *
  * @author Dmytro Dashenkov

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -44,17 +44,17 @@ public class DsProjectionStorage<I> extends ProjectionStorage<I> {
 
     private static final String LAST_EVENT_TIMESTAMP_ID = "datastore_event_timestamp_";
 
-    private final DsRecordStorage<I> entityStorage;
+    private final DsRecordStorage<I> recordStorage;
     private final DsPropertyStorage propertyStorage;
 
     private final DatastoreRecordId lastTimestampId;
 
-    public DsProjectionStorage(DsRecordStorage<I> entityStorage,
+    public DsProjectionStorage(DsRecordStorage<I> recordStorage,
                                DsPropertyStorage propertyStorage,
                                Class<? extends Entity<I, ?>> projectionClass,
                                boolean multitenant) {
         super(multitenant);
-        this.entityStorage = entityStorage;
+        this.recordStorage = recordStorage;
         this.propertyStorage = propertyStorage;
         this.lastTimestampId = of(LAST_EVENT_TIMESTAMP_ID + projectionClass.getCanonicalName());
     }
@@ -78,7 +78,7 @@ public class DsProjectionStorage<I> extends ProjectionStorage<I> {
 
     @Override
     public RecordStorage<I> getRecordStorage() {
-        return entityStorage;
+        return recordStorage;
     }
 
     protected DsPropertyStorage getPropertyStorage() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
@@ -32,6 +32,7 @@ import org.spine3.protobuf.TypeUrl;
 import org.spine3.server.stand.AggregateStateId;
 import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.EntityStorageRecord;
+import org.spine3.server.storage.RecordStorage;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -117,6 +118,11 @@ public class DsStandStorage extends StandStorage {
     protected void writeRecord(AggregateStateId id, EntityStorageRecord record) {
         final DatastoreRecordId recordId = of(id);
         recordStorage.write(recordId, record);
+    }
+
+    @SuppressWarnings("unused") // Part of API
+    protected RecordStorage<DatastoreRecordId> getRecordStorage() {
+        return recordStorage;
     }
 
     private static Iterable<DatastoreRecordId> transformIds(Iterable<AggregateStateId> ids) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
@@ -148,7 +148,7 @@ public class DsStandStorage extends StandStorage {
         return new Function<Object, AggregateStateId>() {
             @Override
             public AggregateStateId apply(@Nullable Object input) {
-                checkNotNull(input, "String ID must not be null.");
+                checkNotNull(input, "Aggregate ID must not be null.");
                 final AggregateStateId id = AggregateStateId.of(input, type);
                 return id;
             }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreIdentifiersShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreIdentifiersShould.java
@@ -36,7 +36,7 @@ public class DatastoreIdentifiersShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(Tests.hasPrivateUtilityConstructor(DatastoreIdentifiers.class));
+        assertTrue(Tests.hasPrivateParameterlessCtor(DatastoreIdentifiers.class));
     }
 
     @Test(expected = IllegalStateException.class)

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastorePropertiesShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastorePropertiesShould.java
@@ -30,6 +30,6 @@ import static org.junit.Assert.assertTrue;
 public class DatastorePropertiesShould {
     @Test
     public void have_private_constructor() {
-        assertTrue(Tests.hasPrivateUtilityConstructor(DatastoreProperties.class));
+        assertTrue(Tests.hasPrivateParameterlessCtor(DatastoreProperties.class));
     }
 }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -84,7 +84,7 @@ public class DatastoreWrapperShould {
     @Test
     public void support_big_bulk_reads() {
         final int bulkSize = 1001;
-        final DatastoreWrapper wrapper = TestDatastoreWrapper.wrap(Given.testDatastore(), false);
+        final TestDatastoreWrapper wrapper = TestDatastoreWrapper.wrap(Given.testDatastore(), false);
         final Map<Key, Entity> entities = Given.nEntities(bulkSize, wrapper);
         for (Entity record : entities.values()) {
             wrapper.create(record);
@@ -101,6 +101,8 @@ public class DatastoreWrapperShould {
         final Collection<Entity> sourceEntities = entities.values();
         assertEquals(sourceEntities.size(), readEntities.size());
         assertTrue(sourceEntities.containsAll(readEntities));
+
+        wrapper.dropAllTables();
     }
 
     private static class Given {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -112,7 +112,7 @@ public class DatastoreWrapperShould {
         wrapper.createOrUpdate(secondPart);
         wrapper.createOrUpdate(thirdPart);
 
-        // Wait some time to make sure the writing is complete
+        // Wait for some time to make sure the writing is complete
         try {
             Thread.sleep(bulkSize * 5);
         } catch (InterruptedException e) {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsStandStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsStandStorageShould.java
@@ -22,10 +22,14 @@ package org.spine3.server.storage.datastore;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.spine3.server.stand.AggregateStateId;
 import org.spine3.server.stand.StandStorageShould;
 import org.spine3.server.storage.AbstractStorage;
 import org.spine3.server.storage.EntityStorageRecord;
+import org.spine3.server.storage.RecordStorage;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Dmytro Dashenkov
@@ -43,6 +47,12 @@ public class DsStandStorageShould extends StandStorageShould {
     @After
     public void tearDown() throws Exception {
         LOCAL_DATASTORE_STORAGE_FACTORY.tearDown();
+    }
+
+    @Test
+    public void contain_record_storage() {
+        final RecordStorage<?> recordStorage = ((DsStandStorage) getStorage()).getRecordStorage();
+        assertNotNull(recordStorage);
     }
 
     @SuppressWarnings("unchecked")

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/EntitiesShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/EntitiesShould.java
@@ -45,7 +45,7 @@ public class EntitiesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(Tests.hasPrivateUtilityConstructor(Entities.class));
+        assertTrue(Tests.hasPrivateParameterlessCtor(Entities.class));
     }
 
     @Test

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/IdTransformerShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/IdTransformerShould.java
@@ -36,7 +36,7 @@ public class IdTransformerShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(Tests.hasPrivateUtilityConstructor(IdTransformer.class));
+        assertTrue(Tests.hasPrivateParameterlessCtor(IdTransformer.class));
     }
 
     @Test

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreStorageFactory.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreStorageFactory.java
@@ -146,10 +146,10 @@ class TestDatastoreStorageFactory extends DatastoreStorageFactory {
                 new TestDatastoreStorageFactory(TestingDatastoreSingleton.INSTANCE.value);
     }
 
-    private enum DefaultDatastoreSingleton {
+    enum DefaultDatastoreSingleton {
         INSTANCE;
         @SuppressWarnings("NonSerializableFieldInSerializableClass")
-        private final Datastore value = DEFAULT_LOCAL_OPTIONS.getService();
+        final Datastore value = DEFAULT_LOCAL_OPTIONS.getService();
     }
 
     enum TestingDatastoreSingleton {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -52,7 +52,7 @@ class TestDatastoreWrapper extends DatastoreWrapper {
     /**
      * Due to eventual consistency, {@link #dropTable(String) is performed iteratively until the table has no records}.
      *
-     * This constant represents the maximum number of cleanup attempts before the execution is continued.
+     * This constant represents the maximum number of cleanup attempts before the execution is continued
      */
     private static final int MAX_CLEANUP_ATTEMPTS = 5;
 
@@ -77,19 +77,19 @@ class TestDatastoreWrapper extends DatastoreWrapper {
     }
 
     @Override
-    void createOrUpdate(Entity entity) {
+    public void createOrUpdate(Entity entity) {
         super.createOrUpdate(entity);
         waitForConsistency();
     }
 
     @Override
-    void create(Entity entity) throws DatastoreException {
+    public void create(Entity entity) throws DatastoreException {
         super.create(entity);
         waitForConsistency();
     }
 
     @Override
-    void update(Entity entity) throws DatastoreException {
+    public void update(Entity entity) throws DatastoreException {
         super.update(entity);
         waitForConsistency();
     }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -96,12 +96,11 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
     @Override
     void dropTable(String table) {
-//        if (!waitForConsistency) {
-//            super.dropTable(table);
-//        } else {
-//            dropTableConsistently(table);
-//        }
-        super.dropTable(table);
+        if (!waitForConsistency) {
+            super.dropTable(table);
+        } else {
+            dropTableConsistently(table);
+        }
     }
 
     @SuppressWarnings("BusyWait")   // allow Datastore some time between cleanup attempts.
@@ -141,7 +140,7 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
                 final Key[] keysArray = new Key[keys.size()];
                 keys.toArray(keysArray);
-                delete(keysArray);
+                dropTableInternal(keysArray);
 
                 cleanupAttempts++;
             }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -96,11 +96,12 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
     @Override
     void dropTable(String table) {
-        if (!waitForConsistency) {
-            super.dropTable(table);
-        } else {
-            dropTableConsistently(table);
-        }
+//        if (!waitForConsistency) {
+//            super.dropTable(table);
+//        } else {
+//            dropTableConsistently(table);
+//        }
+        super.dropTable(table);
     }
 
     @SuppressWarnings("BusyWait")   // allow Datastore some time between cleanup attempts.


### PR DESCRIPTION
 - Provide the possibility to read more then __1000__ entities per one method call
 - Provide possibility to use and extend `DatastoreWrapper` from outside of the package
 - Migrate to __Spine__ core __v0.8.0__
 - General clean up