### PR TITLE
Datastore `Kind` improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ project.ext {
     MAVEN_REPOSITORY_URL = 'http://maven.teamdev.com/repository/spine'
     MAVEN_SNAPSHOT_REPOSITORY_URL = 'http://maven.teamdev.com/repository/spine-snapshots'
 
+    GUAVA_VERSION = "20.0"
+
     IS_WINDOWS = org.gradle.internal.os.OperatingSystem.current().isWindows()
 
     publishPlugin = "$rootDir/script/publish.gradle"
@@ -86,7 +88,7 @@ subprojects {
         testCompile group: 'org.spine3', name: 'spine-testutil-core', version: project.SPINE_VERSION, changing: true
 
         // Guava
-        compile group: 'com.google.guava', name: 'guava', version: '20.0'
+        compile group: 'com.google.guava', name: 'guava', version: GUAVA_VERSION
 
         // Findbugs
         compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0'
@@ -100,6 +102,7 @@ subprojects {
             exclude(module: 'hamcrest-core')
         }
         testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+        testCompile group: 'com.google.guava', name: 'guava-testlib', version: GUAVA_VERSION
     }
 
     protobuf {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 project.ext {
     SPINE_VERSION = '0.8.22-SNAPSHOT'
-    GAE_JAVA_VERSION = "0.8.22-SNAPSHOT"
+    GAE_JAVA_VERSION = "0.8.23-SNAPSHOT"
     PROTOBUF_VERSION = '3.2.0'
     SLf4J_VERSION = "1.7.21"
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}"

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -30,7 +30,6 @@ import org.spine3.server.command.CommandStorage;
 import org.spine3.server.entity.Entity;
 import org.spine3.server.event.EventStorage;
 import org.spine3.server.projection.ProjectionStorage;
-import org.spine3.server.stand.AggregateStateId;
 import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.Storage;
@@ -108,8 +107,7 @@ public class DatastoreStorageFactory implements StorageFactory {
 
     @Override
     public StandStorage createStandStorage() {
-        final DsRecordStorage<AggregateStateId> recordStorage
-                = (DsRecordStorage<AggregateStateId>) createRecordStorage(StandStorageRecord.class);
+        final DsStandStorageDelegate recordStorage = new DsStandStorageDelegate(datastore, multitenant);
         final DsStandStorage result = new DsStandStorage(recordStorage, multitenant);
         return result;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -152,7 +152,10 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         final String idString = idToString(id);
         final Query<Entity> query = Query.newEntityQueryBuilder()
                                          .setKind(stateTypeName.value())
-                                         .setFilter(StructuredQuery.PropertyFilter.eq(aggregate_id.toString(), idString))
+                                         .setFilter(
+                                                 StructuredQuery.PropertyFilter.eq(
+                                                         aggregate_id.toString(),
+                                                         idString))
                                          .build();
         final List<Entity> eventEntities = datastore.read(query);
         if (eventEntities.isEmpty()) {
@@ -175,7 +178,8 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
 
         final Collection<Entity> filteredEntities = Collections2.filter(eventEntities,
                                                                         new IsActiveAggregateId(inactiveAggregateKeys));
-        final List<AggregateEventRecord> immutableResult = Entities.entitiesToMessages(filteredEntities, AGGREGATE_RECORD_TYPE_URL);
+        final List<AggregateEventRecord> immutableResult = Entities.entitiesToMessages(filteredEntities,
+                                                                                       AGGREGATE_RECORD_TYPE_URL);
         final List<AggregateEventRecord> records = Lists.newArrayList(immutableResult);
 
         Collections.sort(records, new Comparator<AggregateEventRecord>() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -49,7 +49,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.not;
 import static org.spine3.base.Identifiers.idToString;
 import static org.spine3.server.aggregate.storage.AggregateField.aggregate_id;
-import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
+import static org.spine3.server.storage.datastore.DsProperties.activedEntityPredicate;
 import static org.spine3.server.storage.datastore.DsProperties.addArchivedProperty;
 import static org.spine3.server.storage.datastore.DsProperties.addDeletedProperty;
 import static org.spine3.server.storage.datastore.DsProperties.isArchived;
@@ -161,7 +161,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
 
         final Collection<Entity> aggregateEntityStates = Collections2.filter(
                 getEntityStates(),
-                not(activeEntityPredicate()));
+                not(activedEntityPredicate()));
         final Collection<Key> inactiveAggregateKeys = Collections2.transform(
                 aggregateEntityStates,
                 new Function<Entity, Key>() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -137,7 +137,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         }
 
         final Key key = DsIdentifiers.keyFor(datastore,
-                                             stateTypeName.value(),
+                                             Kind.of(stateTypeName),
                                              DsIdentifiers.of(eventId));
         final Entity incompleteEntity = Entities.messageToEntity(record, key);
         final Entity.Builder builder = Entity.newBuilder(incompleteEntity);
@@ -266,12 +266,12 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
     @Override
     public Iterator<I> index() {
         checkNotClosed();
-        return Indexes.indexIterator(datastore, stateTypeName.value(), idClass);
+        return Indexes.indexIterator(datastore, Kind.of(stateTypeName), idClass);
     }
 
     private Key keyFor(I id) {
         final DatastoreRecordId recordId = generateDatastoreId(id);
-        final Key key = DsIdentifiers.keyFor(datastore, AGGREGATE_LIFECYCLE_KIND.value(), recordId);
+        final Key key = DsIdentifiers.keyFor(datastore, Kind.of(AGGREGATE_LIFECYCLE_KIND), recordId);
         return key;
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -49,11 +49,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.not;
 import static org.spine3.base.Identifiers.idToString;
 import static org.spine3.server.aggregate.storage.AggregateField.aggregate_id;
-import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
 import static org.spine3.server.storage.datastore.DsProperties.addArchivedProperty;
 import static org.spine3.server.storage.datastore.DsProperties.addDeletedProperty;
 import static org.spine3.server.storage.datastore.DsProperties.isArchived;
 import static org.spine3.server.storage.datastore.DsProperties.isDeleted;
+import static org.spine3.server.storage.datastore.Entities.activeEntity;
 
 /**
  * A storage of aggregate root events and snapshots based on Google Cloud Datastore.
@@ -164,7 +164,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
 
         final Collection<Entity> aggregateEntityStates = Collections2.filter(
                 getEntityStates(),
-                not(activeEntityPredicate()));
+                not(activeEntity()));
         final Collection<Key> inactiveAggregateKeys = Collections2.transform(
                 aggregateEntityStates,
                 new Function<Entity, Key>() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -49,7 +49,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.not;
 import static org.spine3.base.Identifiers.idToString;
 import static org.spine3.server.aggregate.storage.AggregateField.aggregate_id;
-import static org.spine3.server.storage.datastore.DsProperties.activedEntityPredicate;
+import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
 import static org.spine3.server.storage.datastore.DsProperties.addArchivedProperty;
 import static org.spine3.server.storage.datastore.DsProperties.addDeletedProperty;
 import static org.spine3.server.storage.datastore.DsProperties.isArchived;
@@ -161,7 +161,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
 
         final Collection<Entity> aggregateEntityStates = Collections2.filter(
                 getEntityStates(),
-                not(activedEntityPredicate()));
+                not(activeEntityPredicate()));
         final Collection<Key> inactiveAggregateKeys = Collections2.transform(
                 aggregateEntityStates,
                 new Function<Entity, Key>() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -103,7 +103,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         checkNotNull(id);
 
         final DatastoreRecordId datastoreId = generateDatastoreId(id);
-        final Optional<Int32Value> count = propertyStorage.read(datastoreId);
+        final Optional<Int32Value> count = propertyStorage.read(datastoreId, Int32Value.getDescriptor());
         final int countValue;
         if (!count.isPresent()) {
             countValue = 0;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsCommandStorage.java
@@ -33,7 +33,6 @@ import org.spine3.base.Failure;
 import org.spine3.server.command.CommandRecord;
 import org.spine3.server.command.CommandStorage;
 import org.spine3.server.command.ProcessingStatus;
-import org.spine3.type.TypeName;
 import org.spine3.type.TypeUrl;
 
 import javax.annotation.Nullable;
@@ -60,7 +59,7 @@ import static org.spine3.validate.Validate.checkNotDefault;
 public class DsCommandStorage extends CommandStorage {
 
     private static final TypeUrl TYPE_URL = TypeUrl.from(CommandRecord.getDescriptor());
-    private static final String KIND = TypeName.from(CommandRecord.getDescriptor()).value();
+    private static final Kind KIND = Kind.of(CommandRecord.getDescriptor());
     private static final String COMMAND_STATUS_PROPERTY_NAME = "command_status";
 
     private final DatastoreWrapper datastore;
@@ -84,7 +83,7 @@ public class DsCommandStorage extends CommandStorage {
     protected Iterator<CommandRecord> read(CommandStatus status) {
         final Filter filter = PropertyFilter.eq(COMMAND_STATUS_PROPERTY_NAME, status.ordinal());
         final Query<Entity> query = Query.newEntityQueryBuilder()
-                                         .setKind(KIND)
+                                         .setKind(KIND.getValue())
                                          .setFilter(filter)
                                          .build();
         final Collection<Entity> entities = datastore.read(query);

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsEventStorage.java
@@ -89,8 +89,7 @@ import static org.spine3.server.storage.datastore.Entities.messageToEntity;
 public class DsEventStorage extends EventStorage {
 
     private final DatastoreWrapper datastore;
-    private static final String KIND = TypeName.from(Event.getDescriptor())
-                                               .value();
+    private static final Kind KIND = Kind.of(Event.getDescriptor());
     private static final TypeUrl RECORD_TYPE_URL = TypeUrl.from(Event.getDescriptor());
 
     private static final Function<Entity, Event> ENTITY_TO_EVENT_RECORD
@@ -188,7 +187,7 @@ public class DsEventStorage extends EventStorage {
 
     private static Query<Entity> queryWithFilter(Filter filter) {
         final Query<Entity> query = Query.newEntityQueryBuilder()
-                                         .setKind(KIND)
+                                         .setKind(KIND.getValue())
                                          .setFilter(filter)
                                          .build();
         return query;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsIdentifiers.java
@@ -53,8 +53,8 @@ public class DsIdentifiers {
      * @param recordId  the ID of the record
      * @return the Datastore {@code Key} instance
      */
-    static Key keyFor(DatastoreWrapper datastore, String kind, DatastoreRecordId recordId) {
-        final KeyFactory keyFactory = datastore.getKeyFactory(kind);
+    static Key keyFor(DatastoreWrapper datastore, Kind kind, DatastoreRecordId recordId) {
+        final KeyFactory keyFactory = datastore.getKeyFactory(kind.getValue());
         final Key key = keyFactory.newKey(recordId.getValue());
 
         return key;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProjectionStorage.java
@@ -69,7 +69,7 @@ public class DsProjectionStorage<I> extends ProjectionStorage<I> {
     @Nullable
     @Override
     public Timestamp readLastHandledEventTime() {
-        final Optional<Timestamp> readTimestamp = propertyStorage.read(lastTimestampId);
+        final Optional<Timestamp> readTimestamp = propertyStorage.read(lastTimestampId, Timestamp.getDescriptor());
 
         if ((!readTimestamp.isPresent()) || Validate.isDefault(readTimestamp.get())) {
             return null;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
@@ -162,7 +162,7 @@ class DsProperties {
         builder.set(producer_id.toString(), producerId);
     }
 
-    static Predicate<Entity> activedEntityPredicate() {
+    static Predicate<Entity> activeEntityPredicate() {
         return NOT_ARCHIVED_OR_DELETED;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
@@ -162,7 +162,7 @@ class DsProperties {
         builder.set(producer_id.toString(), producerId);
     }
 
-    static Predicate<Entity> activeEntityPredicate() {
+    static Predicate<Entity> activedEntityPredicate() {
         return NOT_ARCHIVED_OR_DELETED;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
@@ -22,7 +22,6 @@ package org.spine3.server.storage.datastore;
 
 import com.google.cloud.datastore.DateTime;
 import com.google.cloud.datastore.Entity;
-import com.google.common.base.Predicate;
 import com.google.protobuf.Message;
 import com.google.protobuf.TimestampOrBuilder;
 import org.spine3.base.Event;
@@ -32,7 +31,6 @@ import org.spine3.protobuf.Messages;
 import org.spine3.server.storage.EntityField;
 import org.spine3.server.storage.LifecycleFlagField;
 
-import javax.annotation.Nullable;
 import java.util.Date;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -57,17 +55,7 @@ import static org.spine3.server.storage.LifecycleFlagField.archived;
 @SuppressWarnings("UtilityClass")
 class DsProperties {
 
-    private static final Predicate<Entity> NOT_ARCHIVED_OR_DELETED = new Predicate<Entity>() {
-        @Override
-        public boolean apply(@Nullable Entity input) {
-            if (input == null) {
-                return false;
-            }
-            final boolean isNotArchived = !isArchived(input);
-            final boolean isNotDeleted = !isDeleted(input);
-            return isNotArchived && isNotDeleted;
-        }
-    };
+
 
     private DsProperties() {
     }
@@ -160,9 +148,5 @@ class DsProperties {
                      .getProducerId());
         builder.set(event_id.toString(), eventId);
         builder.set(producer_id.toString(), producerId);
-    }
-
-    static Predicate<Entity> activeEntityPredicate() {
-        return NOT_ARCHIVED_OR_DELETED;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsProperties.java
@@ -55,8 +55,6 @@ import static org.spine3.server.storage.LifecycleFlagField.archived;
 @SuppressWarnings("UtilityClass")
 class DsProperties {
 
-
-
     private DsProperties() {
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
@@ -58,7 +58,7 @@ public class DsPropertyStorage {
         checkNotNull(value);
 
         final Descriptor typeDescriptor = value.getDescriptorForType();
-        final String kind = kindFrom(typeDescriptor);
+        final Kind kind = Kind.of(typeDescriptor);
 
         final Key key = DsIdentifiers.keyFor(datastore, kind, propertyId);
 
@@ -71,7 +71,7 @@ public class DsPropertyStorage {
         checkNotNull(propertyId);
         checkNotNull(targetTypeDescriptor);
 
-        final String kind = kindFrom(targetTypeDescriptor);
+        final Kind kind = Kind.of(targetTypeDescriptor);
 
         final Key key = DsIdentifiers.keyFor(datastore, kind, propertyId);
         final Entity response = datastore.read(key);
@@ -83,10 +83,6 @@ public class DsPropertyStorage {
         final Any anyResult = entityToMessage(response, ANY_TYPE_URL);
         final V result = AnyPacker.unpack(anyResult);
         return Optional.fromNullable(result);
-    }
-
-    private static String kindFrom(Descriptor descriptor) {
-        return descriptor.getFullName();
     }
 
     /**

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -345,6 +345,10 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return new IdRecordPair<>(id, record);
     }
 
+    String getKind() {
+        return kindFrom(typeUrl);
+    }
+
     /**
      * A tuple containing generic record identifier and corresponding {@link EntityRecord}.
      *

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -252,8 +252,9 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     }
 
     protected EntityQuery buildAllQuery(TypeUrl typeUrl) {
+        final String entityKind = kindFrom(typeUrl).getValue();
         final EntityQuery query = Query.newEntityQueryBuilder()
-                                       .setKind(kindFrom(typeUrl))
+                                       .setKind(entityKind)
                                        .build();
         return query;
     }
@@ -301,7 +302,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     }
 
     @Nullable
-    protected String getDefaultKind() {
+    protected Kind getDefaultKind() {
         return null;
     }
 
@@ -310,24 +311,23 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return id;
     }
 
-    private String kindFrom(EntityRecord record) {
-        final String defaultKind = getDefaultKind();
+    private Kind kindFrom(EntityRecord record) {
+        final Kind defaultKind = getDefaultKind();
         if (defaultKind != null) {
             return defaultKind;
         }
         final Any packedState = record.getState();
         final Message state = AnyPacker.unpack(packedState);
-        final String typeName = state.getDescriptorForType()
-                                     .getFullName();
-        return typeName;
+        final Kind kind = Kind.of(state);
+        return kind;
     }
 
-    private String kindFrom(TypeUrl typeUrl) {
-        final String defaultKind = getDefaultKind();
+    private Kind kindFrom(TypeUrl typeUrl) {
+        final Kind defaultKind = getDefaultKind();
         if (defaultKind != null) {
             return defaultKind;
         }
-        return typeUrl.getTypeName();
+        return Kind.of(typeUrl);
     }
 
     protected IdRecordPair<I> getRecordFromEntity(Entity entity, TypeUrl stateType) {
@@ -345,7 +345,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return new IdRecordPair<>(id, record);
     }
 
-    protected String getKind() {
+    protected Kind getKind() {
         return kindFrom(typeUrl);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -24,7 +24,6 @@ import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -54,7 +53,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.spine3.server.storage.datastore.DsIdentifiers.keyFor;
 import static org.spine3.server.storage.datastore.DsIdentifiers.ofEntityId;
-import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
+import static org.spine3.server.storage.datastore.DsProperties.activedEntityPredicate;
 import static org.spine3.server.storage.datastore.Entities.getEntityStatus;
 import static org.spine3.validate.Validate.isDefault;
 
@@ -70,11 +69,10 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     private final DatastoreWrapper datastore;
     private final TypeUrl typeUrl;
     private final Class<I> idClass;
-    private final String kind;
 
     private static final String VERSION_KEY = "version";
-    private static final TypeUrl RECORD_TYPE_URL = TypeUrl.of(EntityRecord.class);
-    private static final String ID_CONVERSION_ERROR_MESSAGE = "Entity had ID of an invalid type; could not " +
+    protected static final TypeUrl RECORD_TYPE_URL = TypeUrl.of(EntityRecord.class);
+    protected static final String ID_CONVERSION_ERROR_MESSAGE = "Entity had ID of an invalid type; could not " +
             "parse ID from String. " +
             "Note: custom conversion is not supported. " +
             "See org.spine3.base.Identifiers#idToString.";
@@ -104,12 +102,13 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         this.typeUrl = TypeUrl.from(descriptor);
         this.datastore = datastore;
         this.idClass = checkNotNull(idClass);
-        this.kind = descriptor.getFullName();
     }
 
     @Override
     public boolean delete(I id) {
-        final Key key = keyFor(datastore, kind, ofEntityId(id));
+        final Key key = keyFor(datastore,
+                               kindFrom(typeUrl),
+                               ofEntityId(id));
         datastore.delete(key);
 
         // Check presence
@@ -120,7 +119,9 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     @Nullable
     @Override
     protected Optional<EntityRecord> readRecord(I id) {
-        final Key key = keyFor(datastore, kind, ofEntityId(id));
+        final Key key = keyFor(datastore,
+                               kindFrom(typeUrl),
+                               ofEntityId(id));
         final Entity response = datastore.read(key);
 
         if (response == null) {
@@ -130,10 +131,10 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         final EntityRecord record = Entities.entityToMessage(response, RECORD_TYPE_URL);
         final LifecycleFlags entityStatus = getEntityStatus(response);
         final EntityRecord result = isDefault(entityStatus) // Avoid inequality of written and read records
-                                           ? record                // caused by empty {@code EntityStatus} object
-                                           : EntityRecord.newBuilder(record)
-                                                                .setLifecycleFlags(entityStatus)
-                                                                .build();
+                                    ? record                // caused by empty {@code EntityStatus} object
+                                    : EntityRecord.newBuilder(record)
+                                                  .setLifecycleFlags(entityStatus)
+                                                  .build();
 
         return Optional.of(result);
     }
@@ -161,9 +162,9 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
                 final LifecycleFlags entityStatus = getEntityStatus(input);
                 final EntityRecord record = EntityRecord.newBuilder(readRecord)
-                                                                      .setState(wrappedState)
-                                                                      .setLifecycleFlags(entityStatus)
-                                                                      .build();
+                                                        .setState(wrappedState)
+                                                        .setLifecycleFlags(entityStatus)
+                                                        .build();
                 return record;
             }
         };
@@ -178,34 +179,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
     @Override
     protected Map<I, EntityRecord> readAllRecords(final FieldMask fieldMask) {
-        final Function<Entity, IdRecordPair<I>> mapper = new Function<Entity, IdRecordPair<I>>() {
-            @Nullable
-            @Override
-            public IdRecordPair<I> apply(@Nullable Entity input) {
-                if (input == null) {
-                    return null;
-                }
-                // Retrieve ID
-                final I id = IdTransformer.idFromString(input.getKey()
-                                                             .getName(), null);
-                checkState(id != null, ID_CONVERSION_ERROR_MESSAGE);
-
-                // Retrieve record
-                EntityRecord record = Entities.entityToMessage(input, RECORD_TYPE_URL);
-                final Any packedState = record.getState();
-                Message state = AnyPacker.unpack(packedState);
-                final TypeUrl typeUrl = TypeUrl.from(state.getDescriptorForType());
-                state = FieldMasks.applyMask(fieldMask, state, typeUrl);
-                final LifecycleFlags entityStatus = getEntityStatus(input);
-                record = EntityRecord.newBuilder(record)
-                                            .setState(AnyPacker.pack(state))
-                                            .setLifecycleFlags(entityStatus)
-                                            .build();
-                return new IdRecordPair<>(id, record);
-            }
-        };
-
-        return queryAll(mapper, typeUrl, FieldMask.getDefaultInstance());
+        return queryAll(typeUrl, fieldMask);
     }
 
     /**
@@ -230,113 +204,71 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return typeUrl;
     }
 
-    public Map<?, EntityRecord> readAllByType(final TypeUrl typeUrl, final FieldMask fieldMask) {
-        final Function<Entity, IdRecordPair<I>> mapper = new Function<Entity, IdRecordPair<I>>() {
-            @Nullable
-            @Override
-            public IdRecordPair<I> apply(@Nullable Entity input) {
-                if (input == null) {
-                    return null;
-                }
-                // Retrieve ID
-                final I id = IdTransformer.idFromString(input.getKey()
-                                                             .getName(), null);
-                checkState(id != null, ID_CONVERSION_ERROR_MESSAGE);
-
-                // Retrieve record
-                EntityRecord record = Entities.entityToMessage(input, RECORD_TYPE_URL);
-                final Any packedState = record.getState();
-                Message state = AnyPacker.unpack(packedState);
-                state = FieldMasks.applyMask(fieldMask, state, typeUrl);
-                final LifecycleFlags entityStatus = getEntityStatus(input);
-                record = EntityRecord.newBuilder(record)
-                                            .setState(AnyPacker.pack(state))
-                                            .setLifecycleFlags(entityStatus)
-                                            .build();
-                return new IdRecordPair<>(id, record);
-            }
-        };
-
-        return queryAll(mapper, typeUrl, FieldMask.getDefaultInstance());
-    }
-
-    public Map<?, EntityRecord> readAllByType(final TypeUrl typeUrl) {
-        final Function<Entity, IdRecordPair<I>> mapper = new Function<Entity, IdRecordPair<I>>() {
-            @Nullable
-            @Override
-            public IdRecordPair<I> apply(@Nullable Entity input) {
-                if (input == null) {
-                    return null;
-                }
-                // Retrieve ID
-                final I id = IdTransformer.idFromString(input.getKey()
-                                                             .getName(), null);
-                checkState(id != null, ID_CONVERSION_ERROR_MESSAGE);
-
-                // Retrieve record
-                EntityRecord record = Entities.entityToMessage(input, RECORD_TYPE_URL);
-                final Any packedState = record.getState();
-                Message state = AnyPacker.unpack(packedState);
-                final LifecycleFlags entityStatus = getEntityStatus(input);
-                record = EntityRecord.newBuilder(record)
-                                            .setState(AnyPacker.pack(state))
-                                            .setLifecycleFlags(entityStatus)
-                                            .build();
-
-                return new IdRecordPair<>(id, record);
-            }
-        };
-
-        return queryAll(mapper, typeUrl, FieldMask.getDefaultInstance());
-    }
-
     private Iterable<EntityRecord> lookup(
             Iterable<I> ids,
             Function<Entity, EntityRecord> transformer) {
 
         final Collection<Key> keys = new LinkedList<>();
         for (I id : ids) {
-            final Key key = keyFor(datastore, kind, ofEntityId(id));
+            final Key key = keyFor(datastore,
+                                   kindFrom(typeUrl),
+                                   ofEntityId(id));
             keys.add(key);
         }
 
         final List<Entity> results = datastore.read(keys);
-        final Collection<Entity> filteredResults = Collections2.filter(results, activeEntityPredicate());
+        final Collection<Entity> filteredResults = Collections2.filter(results, activedEntityPredicate());
         final Collection<EntityRecord> records = Collections2.transform(filteredResults, transformer);
         return Collections.unmodifiableCollection(records);
     }
 
-    private Map<I, EntityRecord> queryAll(Function<Entity, IdRecordPair<I>> transformer,
-                                          TypeUrl typeUrl,
-                                          FieldMask fieldMask) {
-
-        EntityQuery.Builder builder = Query.newEntityQueryBuilder()
-                                           .setKind(kind);
-        final EntityQuery query = builder.build();
+    protected Map<I, EntityRecord> queryAll(TypeUrl typeUrl,
+                                            FieldMask fieldMask) {
+        final EntityQuery query = buildAllQuery(typeUrl);
 
         final List<Entity> results = datastore.read(query);
 
-        final Predicate<Entity> archivedAndDeletedFilter = activeEntityPredicate();
+        final Predicate<Entity> archivedAndDeletedFilter = activedEntityPredicate();
 
         final ImmutableMap.Builder<I, EntityRecord> records = new ImmutableMap.Builder<>();
         for (Entity entity : results) {
             if (!archivedAndDeletedFilter.apply(entity)) {
                 continue;
             }
-            final IdRecordPair<I> recordPair = transformer.apply(entity);
-            checkNotNull(recordPair, "Datastore may not contain null records.");
-            final EntityRecord fullRecord = recordPair.getRecord();
-            final Message fullState = AnyPacker.unpack(fullRecord.getState());
-            final Message maskedState = FieldMasks.applyMask(fieldMask, fullState, typeUrl);
-            final LifecycleFlags entityStatus = getEntityStatus(entity);
-            final EntityRecord maskedRecord = EntityRecord.newBuilder(fullRecord)
-                                                                        .setState(AnyPacker.pack(maskedState))
-                                                                        .setLifecycleFlags(entityStatus)
-                                                                        .build();
-            records.put(recordPair.getId(), maskedRecord);
+            final IdRecordPair<I> recordPair = getRecordFromEntity(entity, typeUrl);
+            EntityRecord record = recordPair.getRecord();
+
+            if (!isDefault(fieldMask)) {
+                Message state = AnyPacker.unpack(record.getState());
+                state = FieldMasks.applyMask(fieldMask, state, typeUrl);
+                record = EntityRecord.newBuilder(record)
+                                     .setState(AnyPacker.pack(state))
+                                     .build();
+            }
+            records.put(recordPair.getId(), record);
         }
 
         return records.build();
+    }
+
+    protected EntityQuery buildAllQuery(TypeUrl typeUrl) {
+        final EntityQuery query = Query.newEntityQueryBuilder()
+                                       .setKind(kindFrom(typeUrl))
+                                       .build();
+        return query;
+    }
+
+    protected Entity entityRecordToEntity(I id, EntityRecord record) {
+        final Key key = keyFor(datastore,
+                               kindFrom(record),
+                               ofEntityId(id));
+        final Entity incompleteEntity = Entities.messageToEntity(record, key);
+
+        final Entity.Builder entity = Entity.newBuilder(incompleteEntity);
+        entity.set(VERSION_KEY, record.getVersion()
+                                      .getNumber());
+        final Entity completeEntity = entity.build();
+        return completeEntity;
     }
 
     @Override
@@ -344,11 +276,8 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         checkNotNull(id, "ID is null.");
         checkNotNull(entityStorageRecord, "Message is null.");
 
-        final Key key = keyFor(datastore, kind, ofEntityId(id));
-        final Entity incompleteEntity = Entities.messageToEntity(entityStorageRecord, key);
-        final Entity.Builder entity = Entity.newBuilder(incompleteEntity);
-        entity.set(VERSION_KEY, entityStorageRecord.getVersion().getNumber());
-        datastore.createOrUpdate(entity.build());
+        final Entity entity = entityRecordToEntity(id, entityStorageRecord);
+        datastore.createOrUpdate(entity);
     }
 
     @Override
@@ -357,15 +286,8 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
         final Collection<Entity> entitiesToWrite = new ArrayList<>(records.size());
         for (Map.Entry<I, EntityRecord> record : records.entrySet()) {
-            final EntityRecord entityStorageRecord = record.getValue();
-            final Key key = keyFor(
-                    datastore,
-                    kind,
-                    ofEntityId(record.getKey()));
-            final Entity incompleteEntity = Entities.messageToEntity(entityStorageRecord, key);
-            final Entity.Builder entity = Entity.newBuilder(incompleteEntity);
-            entity.set(VERSION_KEY, entityStorageRecord.getVersion().getNumber());
-            entitiesToWrite.add(entity.build());
+            final Entity entity = entityRecordToEntity(record.getKey(), record.getValue());
+            entitiesToWrite.add(entity);
         }
         datastore.createOrUpdate(entitiesToWrite);
     }
@@ -373,12 +295,54 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     @Override
     public Iterator<I> index() {
         checkNotClosed();
-        return Indexes.indexIterator(datastore, kind, idClass);
+        return Indexes.indexIterator(datastore,
+                                     kindFrom(typeUrl),
+                                     idClass);
     }
 
-    @VisibleForTesting
-    String getKind() {
-        return kind;
+    @Nullable
+    protected String getDefaultKind() {
+        return null;
+    }
+
+    protected I unpackKey(Key key, @SuppressWarnings("unused") TypeUrl stateType) {
+        final I id = IdTransformer.idFromString(key.getName(), null);
+        return id;
+    }
+
+    private String kindFrom(EntityRecord record) {
+        final String defaultKind = getDefaultKind();
+        if (defaultKind != null) {
+            return defaultKind;
+        }
+        final Any packedState = record.getState();
+        final Message state = AnyPacker.unpack(packedState);
+        final String typeName = state.getDescriptorForType()
+                                     .getFullName();
+        return typeName;
+    }
+
+    private String kindFrom(TypeUrl typeUrl) {
+        final String defaultKind = getDefaultKind();
+        if (defaultKind != null) {
+            return defaultKind;
+        }
+        return typeUrl.getTypeName();
+    }
+
+    protected IdRecordPair<I> getRecordFromEntity(Entity entity, TypeUrl stateType) {
+        // Retrieve ID
+        final I id = unpackKey(entity.getKey(), stateType);
+        checkState(id != null, ID_CONVERSION_ERROR_MESSAGE);
+
+        // Retrieve record
+        EntityRecord record = Entities.entityToMessage(entity, RECORD_TYPE_URL);
+        final Any packedState = record.getState();
+        Message state = AnyPacker.unpack(packedState);
+        record = EntityRecord.newBuilder(record)
+                             .setState(AnyPacker.pack(state))
+                             .build();
+        return new IdRecordPair<>(id, record);
     }
 
     /**
@@ -386,21 +350,21 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
      *
      * @param <I> type of the {@link org.spine3.server.entity.Entity entity} ID.
      */
-    private static class IdRecordPair<I> {
+    protected static class IdRecordPair<I> {
 
         private final I id;
         private final EntityRecord record;
 
-        private IdRecordPair(I id, EntityRecord record) {
+        protected IdRecordPair(I id, EntityRecord record) {
             this.id = id;
             this.record = record;
         }
 
-        private I getId() {
+        protected I getId() {
             return id;
         }
 
-        private EntityRecord getRecord() {
+        protected EntityRecord getRecord() {
             return record;
         }
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -24,7 +24,6 @@ import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.StructuredQuery;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -387,8 +386,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     @Override
     public Iterator<I> index() {
         checkNotClosed();
-        final StructuredQuery.Filter filter = PropertyFilter.eq(TYPE_URL_PROPERTY_NAME, typeUrl.getTypeName());
-        return Indexes.indexIterator(datastore, kind, idClass, filter);
+        return Indexes.indexIterator(datastore, kind, idClass);
     }
 
     @VisibleForTesting

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -107,7 +107,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     @Override
     public boolean delete(I id) {
         final Key key = keyFor(datastore,
-                               kindFrom(typeUrl),
+                               getKind(),
                                ofEntityId(id));
         datastore.delete(key);
 
@@ -120,7 +120,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     @Override
     protected Optional<EntityRecord> readRecord(I id) {
         final Key key = keyFor(datastore,
-                               kindFrom(typeUrl),
+                               getKind(),
                                ofEntityId(id));
         final Entity response = datastore.read(key);
 
@@ -296,7 +296,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     public Iterator<I> index() {
         checkNotClosed();
         return Indexes.indexIterator(datastore,
-                                     kindFrom(typeUrl),
+                                     getKind(),
                                      idClass);
     }
 
@@ -345,7 +345,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         return new IdRecordPair<>(id, record);
     }
 
-    String getKind() {
+    protected String getKind() {
         return kindFrom(typeUrl);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -53,7 +53,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.spine3.server.storage.datastore.DsIdentifiers.keyFor;
 import static org.spine3.server.storage.datastore.DsIdentifiers.ofEntityId;
-import static org.spine3.server.storage.datastore.DsProperties.activedEntityPredicate;
+import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
 import static org.spine3.server.storage.datastore.Entities.getEntityStatus;
 import static org.spine3.validate.Validate.isDefault;
 
@@ -217,7 +217,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         }
 
         final List<Entity> results = datastore.read(keys);
-        final Collection<Entity> filteredResults = Collections2.filter(results, activedEntityPredicate());
+        final Collection<Entity> filteredResults = Collections2.filter(results, activeEntityPredicate());
         final Collection<EntityRecord> records = Collections2.transform(filteredResults, transformer);
         return Collections.unmodifiableCollection(records);
     }
@@ -228,7 +228,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
         final List<Entity> results = datastore.read(query);
 
-        final Predicate<Entity> archivedAndDeletedFilter = activedEntityPredicate();
+        final Predicate<Entity> archivedAndDeletedFilter = activeEntityPredicate();
 
         final ImmutableMap.Builder<I, EntityRecord> records = new ImmutableMap.Builder<>();
         for (Entity entity : results) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -53,7 +53,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.spine3.server.storage.datastore.DsIdentifiers.keyFor;
 import static org.spine3.server.storage.datastore.DsIdentifiers.ofEntityId;
-import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
+import static org.spine3.server.storage.datastore.Entities.activeEntity;
 import static org.spine3.server.storage.datastore.Entities.getEntityStatus;
 import static org.spine3.validate.Validate.isDefault;
 
@@ -217,7 +217,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         }
 
         final List<Entity> results = datastore.read(keys);
-        final Collection<Entity> filteredResults = Collections2.filter(results, activeEntityPredicate());
+        final Collection<Entity> filteredResults = Collections2.filter(results, activeEntity());
         final Collection<EntityRecord> records = Collections2.transform(filteredResults, transformer);
         return Collections.unmodifiableCollection(records);
     }
@@ -228,7 +228,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
         final List<Entity> results = datastore.read(query);
 
-        final Predicate<Entity> archivedAndDeletedFilter = activeEntityPredicate();
+        final Predicate<Entity> archivedAndDeletedFilter = activeEntity();
 
         final ImmutableMap.Builder<I, EntityRecord> records = new ImmutableMap.Builder<>();
         for (Entity entity : results) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorage.java
@@ -43,9 +43,9 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")   // Part of API
 public class DsStandStorage extends StandStorage {
 
-    private final DsRecordStorage<AggregateStateId> recordStorage;
+    private final DsStandStorageDelegate recordStorage;
 
-    public DsStandStorage(DsRecordStorage<AggregateStateId> recordStorage, boolean multitenant) {
+    public DsStandStorage(DsStandStorageDelegate recordStorage, boolean multitenant) {
         super(multitenant);
         this.recordStorage = recordStorage;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.EntityQuery;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.StructuredQuery.Filter;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Message;
+import org.spine3.protobuf.AnyPacker;
+import org.spine3.server.entity.EntityRecord;
+import org.spine3.server.entity.FieldMasks;
+import org.spine3.server.stand.AggregateStateId;
+import org.spine3.type.TypeUrl;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.cloud.datastore.StructuredQuery.PropertyFilter.eq;
+import static org.spine3.server.storage.datastore.DsProperties.activedEntityPredicate;
+import static org.spine3.validate.Validate.isDefault;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
+
+    private static final String KIND = "spine3.stand_storage_record";
+
+    private static final String TYPE_URL_KEY = "type_name";
+
+    /**
+     * Creates a new storage instance.
+     *
+     * @param datastore the Datastore implementation to use
+     */
+    public DsStandStorageDelegate(DatastoreWrapper datastore, boolean multitenant) {
+        super(EntityRecord.getDescriptor(), datastore, multitenant, AggregateStateId.class);
+    }
+
+    @SuppressWarnings("MethodDoesntCallSuperMethod") // Overrides a pure method behavior
+    @Override
+    protected String getDefaultKind() {
+        return KIND;
+    }
+
+    @Override
+    protected Entity entityRecordToEntity(AggregateStateId id, EntityRecord record) {
+        final Entity incompleteEntity = super.entityRecordToEntity(id, record);
+        final String typeUrl = record.getState()
+                                     .getTypeUrl();
+        final Entity.Builder builder = Entity.newBuilder(incompleteEntity)
+                                             .set(TYPE_URL_KEY, typeUrl);
+        final Entity completeEntity = builder.build();
+        return completeEntity;
+    }
+
+    public Map<?, EntityRecord> readAllByType(final TypeUrl typeUrl, final FieldMask fieldMask) {
+        return queryAllByType(typeUrl,
+                              fieldMask);
+    }
+
+    public Map<?, EntityRecord> readAllByType(final TypeUrl typeUrl) {
+        return queryAllByType(typeUrl,
+                              FieldMask.getDefaultInstance());
+    }
+
+    protected Map<AggregateStateId, EntityRecord> queryAllByType(TypeUrl typeUrl,
+                                                                 FieldMask fieldMask) {
+        final EntityQuery query = buildByTypeQuery(typeUrl);
+
+        final List<Entity> results = getDatastore().read(query);
+
+        final Predicate<Entity> archivedAndDeletedFilter = activedEntityPredicate();
+
+        final ImmutableMap.Builder<AggregateStateId, EntityRecord> records = new ImmutableMap.Builder<>();
+        for (Entity entity : results) {
+            if (!archivedAndDeletedFilter.apply(entity)) {
+                continue;
+            }
+            final IdRecordPair<AggregateStateId> recordPair = getRecordFromEntity(entity, typeUrl);
+            EntityRecord record = recordPair.getRecord();
+
+            if (!isDefault(fieldMask)) {
+                Message state = AnyPacker.unpack(record.getState());
+                state = FieldMasks.applyMask(fieldMask, state, typeUrl);
+                record = EntityRecord.newBuilder(record)
+                                     .setState(AnyPacker.pack(state))
+                                     .build();
+            }
+            records.put(recordPair.getId(), record);
+        }
+
+        return records.build();
+    }
+
+    protected EntityQuery buildByTypeQuery(TypeUrl typeUrl) {
+        final EntityQuery incompleteQuery = buildAllQuery(typeUrl);
+        final Filter filter = eq(TYPE_URL_KEY, typeUrl.value());
+        final EntityQuery query = incompleteQuery.toBuilder()
+                                                 .setFilter(filter)
+                                                 .build();
+        return query;
+    }
+
+    @SuppressWarnings("MethodDoesntCallSuperMethod") // Overrides parent behavior
+    @Override
+    protected AggregateStateId unpackKey(Key key, TypeUrl stateType) {
+        final Object genericId = IdTransformer.idFromString(key.getName(), null);
+        final AggregateStateId aggregateStateId = AggregateStateId.of(genericId, stateType);
+        return aggregateStateId;
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
@@ -42,9 +42,12 @@ import static org.spine3.server.storage.datastore.DsProperties.activedEntityPred
 import static org.spine3.validate.Validate.isDefault;
 
 /**
+ * A {@link org.spine3.server.storage.RecordStorage RecordStorage} to which {@link DsStandStorage} delegates its
+ * operations.
+ *
  * @author Dmytro Dashenkov
  */
-public class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
+class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
 
     private static final Kind KIND = Kind.of("spine3.stand_storage_record");
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.cloud.datastore.StructuredQuery.PropertyFilter.eq;
-import static org.spine3.server.storage.datastore.DsProperties.activedEntityPredicate;
+import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
 import static org.spine3.validate.Validate.isDefault;
 
 /**
@@ -95,7 +95,7 @@ class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
 
         final List<Entity> results = getDatastore().read(query);
 
-        final Predicate<Entity> archivedAndDeletedFilter = activedEntityPredicate();
+        final Predicate<Entity> archivedAndDeletedFilter = activeEntityPredicate();
 
         final ImmutableMap.Builder<AggregateStateId, EntityRecord> records = new ImmutableMap.Builder<>();
         for (Entity entity : results) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
@@ -46,7 +46,7 @@ import static org.spine3.validate.Validate.isDefault;
  */
 public class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
 
-    private static final String KIND = "spine3.stand_storage_record";
+    private static final Kind KIND = Kind.of("spine3.stand_storage_record");
 
     private static final String TYPE_URL_KEY = "type_name";
 
@@ -61,7 +61,7 @@ public class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
 
     @SuppressWarnings("MethodDoesntCallSuperMethod") // Overrides a pure method behavior
     @Override
-    protected String getDefaultKind() {
+    protected Kind getDefaultKind() {
         return KIND;
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.cloud.datastore.StructuredQuery.PropertyFilter.eq;
-import static org.spine3.server.storage.datastore.DsProperties.activeEntityPredicate;
+import static org.spine3.server.storage.datastore.Entities.activeEntity;
 import static org.spine3.validate.Validate.isDefault;
 
 /**
@@ -95,7 +95,7 @@ class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
 
         final List<Entity> results = getDatastore().read(query);
 
-        final Predicate<Entity> archivedAndDeletedFilter = activeEntityPredicate();
+        final Predicate<Entity> archivedAndDeletedFilter = activeEntity();
 
         final ImmutableMap.Builder<AggregateStateId, EntityRecord> records = new ImmutableMap.Builder<>();
         for (Entity entity : results) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Entities.java
@@ -24,6 +24,7 @@ import com.google.cloud.datastore.Blob;
 import com.google.cloud.datastore.BlobValue;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
@@ -51,6 +52,18 @@ import static org.spine3.server.storage.datastore.DsProperties.isDeleted;
  */
 @SuppressWarnings("UtilityClass")
 class Entities {
+
+    private static final Predicate<Entity> NOT_ARCHIVED_OR_DELETED = new Predicate<Entity>() {
+        @Override
+        public boolean apply(@Nullable Entity input) {
+            if (input == null) {
+                return false;
+            }
+            final boolean isNotArchived = !isArchived(input);
+            final boolean isNotDeleted = !isDeleted(input);
+            return isNotArchived && isNotDeleted;
+        }
+    };
 
     private static final String DEFAULT_MESSAGE_FACTORY_METHOD_NAME = "getDefaultInstance";
 
@@ -153,6 +166,10 @@ class Entities {
                                                   .setDeleted(deleted)
                                                   .build();
         return result;
+    }
+
+    static Predicate<Entity> activeEntity() {
+        return NOT_ARCHIVED_OR_DELETED;
     }
 
     @SuppressWarnings("unchecked")

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Indexes.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Indexes.java
@@ -56,14 +56,14 @@ public class Indexes {
      * @return an {@link Iterator} of the IDs matching given record kind
      */
     public static <I> Iterator<I> indexIterator(DatastoreWrapper datastore,
-                                                String kind,
+                                                Kind kind,
                                                 Class<I> idClass) {
         checkNotNull(datastore);
         checkNotNull(kind);
         checkNotNull(idClass);
 
         final EntityQuery.Builder query = Query.newEntityQueryBuilder()
-                                               .setKind(kind);
+                                               .setKind(kind.getValue());
         final Iterable<Entity> allEntities = datastore.read(query.build());
         final Iterator<I> idIterator = Iterators.transform(allEntities.iterator(),
                                                            idExtractor(idClass));

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Indexes.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Indexes.java
@@ -24,7 +24,6 @@ import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.StructuredQuery;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.google.common.reflect.TypeToken;
@@ -50,47 +49,24 @@ public class Indexes {
     /**
      * Retrieves the ID index for the given {@code kind} or the storage records.
      *
-     * <p>A call to this method is equivalent to {@code indexIterator(datastore, kind, idClass, null)}.
-     *
      * @param datastore datastore to get the indexes for
      * @param kind      the kind if the records in the datastore
      * @param idClass   {@link Class} of the record ID
      * @param <I>       type of the IDs to retrieve
      * @return an {@link Iterator} of the IDs matching given record kind
-     * @see #indexIterator(DatastoreWrapper, String, Class, StructuredQuery.Filter)
      */
     public static <I> Iterator<I> indexIterator(DatastoreWrapper datastore,
                                                 String kind,
                                                 Class<I> idClass) {
-        return indexIterator(datastore, kind, idClass, null);
-    }
-
-    /**
-     * Retrieves the ID index for the given {@code kind} or the storage records.
-     *
-     * @param datastore datastore to get the indexes for
-     * @param kind      the kind if the records in the datastore
-     * @param idClass   {@link Class} of the record ID
-     * @param filter    custom filters for selecting only a subset of the records of given type from datastore;
-     *                  {@code null} stands for no custom filters
-     * @param <I>       type of the IDs to retrieve
-     * @return an {@link Iterator} of the IDs matching given record kind and filter
-     */
-    public static <I> Iterator<I> indexIterator(DatastoreWrapper datastore,
-                                                String kind,
-                                                Class<I> idClass,
-                                                @Nullable StructuredQuery.Filter filter) {
         checkNotNull(datastore);
         checkNotNull(kind);
         checkNotNull(idClass);
 
         final EntityQuery.Builder query = Query.newEntityQueryBuilder()
                                                .setKind(kind);
-        if (filter != null) {
-            query.setFilter(filter);
-        }
         final Iterable<Entity> allEntities = datastore.read(query.build());
-        final Iterator<I> idIterator = Iterators.transform(allEntities.iterator(), idExtractor(idClass));
+        final Iterator<I> idIterator = Iterators.transform(allEntities.iterator(),
+                                                           idExtractor(idClass));
         return idIterator;
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Kind.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Kind.java
@@ -25,17 +25,25 @@ import com.google.protobuf.Message;
 import org.spine3.type.TypeName;
 import org.spine3.type.TypeUrl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
+ * A data transfer object representing a Datastore
+ * <a href="https://cloud.google.com/datastore/docs/concepts/entities#kinds_and_identifiers>kind</a>.
+ *
  * @author Dmytro Dashenkov
  */
 public final class Kind {
 
+    private static final String INVALID_KIND_ERROR_MESSAGE =
+            "Datastore kind cannot start with \"__\". See https://cloud.google.com/datastore/docs/concepts/entities#kinds_and_identifiers for more info.";
+    private static final String FORBIDDEN_PREFIX = "__";
+
     private final String value;
 
     private Kind(String value) {
-        this.value = checkNotNull(value);
+        this.value = checkValidKind(value);
     }
 
     public static Kind of(String value) {
@@ -60,5 +68,11 @@ public final class Kind {
 
     public String getValue() {
         return value;
+    }
+
+    private static String checkValidKind(String kind) {
+        checkNotNull(kind);
+        checkArgument(!kind.startsWith(FORBIDDEN_PREFIX), INVALID_KIND_ERROR_MESSAGE);
+        return kind;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Kind.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Kind.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Message;
+import org.spine3.type.TypeName;
+import org.spine3.type.TypeUrl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public final class Kind {
+
+    private final String value;
+
+    private Kind(String value) {
+        this.value = checkNotNull(value);
+    }
+
+    public static Kind of(String value) {
+        return new Kind(value);
+    }
+
+    public static Kind of(TypeUrl typeUrl) {
+        return new Kind(typeUrl.getTypeName());
+    }
+
+    public static Kind of(Descriptor descriptor) {
+        return new Kind(descriptor.getFullName());
+    }
+
+    public static Kind of(Message message) {
+        return of(message.getDescriptorForType());
+    }
+
+    public static Kind of(TypeName typeName) {
+        return new Kind(typeName.value());
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
@@ -33,6 +33,7 @@ import org.spine3.server.storage.StorageFactory;
 import org.spine3.test.aggregate.ProjectId;
 import org.spine3.test.storage.Project;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -74,13 +75,13 @@ public class DatastoreStorageFactoryShould {
         assertNotNull(storage);
     }
 
-//    @Test
-//    public void create_separate_record_storage_per_state_type() {
-//        final DsRecordStorage<?> storage = (DsRecordStorage<?>) datastoreFactory.createRecordStorage(TestEntity.class);
-//        final DsRecordStorage<?> differentStorage =
-//                (DsRecordStorage<?>) datastoreFactory.createRecordStorage(DifferentTestEntity.class);
-//        assertNotEquals(storage.getKind(), differentStorage.getKind());
-//    }
+    @Test
+    public void create_separate_record_storage_per_state_type() {
+        final DsRecordStorage<?> storage = (DsRecordStorage<?>) datastoreFactory.createRecordStorage(TestEntity.class);
+        final DsRecordStorage<?> differentStorage =
+                (DsRecordStorage<?>) datastoreFactory.createRecordStorage(DifferentTestEntity.class);
+        assertNotEquals(storage.getKind(), differentStorage.getKind());
+    }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
@@ -96,7 +97,7 @@ public class DatastoreStorageFactoryShould {
         }
     }
 
-    private static class  DifferentTestEntity extends AbstractEntity<String, Project> {
+    private static class DifferentTestEntity extends AbstractEntity<String, Project> {
         protected DifferentTestEntity(String id) {
             super(id);
         }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
@@ -31,7 +31,9 @@ import org.spine3.server.event.EventStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.StorageFactory;
 import org.spine3.test.aggregate.ProjectId;
+import org.spine3.test.storage.Project;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -73,6 +75,14 @@ public class DatastoreStorageFactoryShould {
         assertNotNull(storage);
     }
 
+    @Test
+    public void create_separate_record_storage_per_state_type() {
+        final DsRecordStorage<?> storage = (DsRecordStorage<?>) datastoreFactory.createRecordStorage(TestEntity.class);
+        final DsRecordStorage<?> differentStorage =
+                (DsRecordStorage<?>) datastoreFactory.createRecordStorage(DifferentTestEntity.class);
+        assertNotEquals(storage.getKind(), differentStorage.getKind());
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void fail_to_create_aggregate_storage_not_using_class_parameter() {
@@ -83,6 +93,12 @@ public class DatastoreStorageFactoryShould {
     private static class TestEntity extends AbstractEntity<String, StringValue> {
 
         private TestEntity(String id) {
+            super(id);
+        }
+    }
+
+    private static class  DifferentTestEntity extends AbstractEntity<String, Project> {
+        protected DifferentTestEntity(String id) {
             super(id);
         }
     }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryShould.java
@@ -33,7 +33,6 @@ import org.spine3.server.storage.StorageFactory;
 import org.spine3.test.aggregate.ProjectId;
 import org.spine3.test.storage.Project;
 
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -75,13 +74,13 @@ public class DatastoreStorageFactoryShould {
         assertNotNull(storage);
     }
 
-    @Test
-    public void create_separate_record_storage_per_state_type() {
-        final DsRecordStorage<?> storage = (DsRecordStorage<?>) datastoreFactory.createRecordStorage(TestEntity.class);
-        final DsRecordStorage<?> differentStorage =
-                (DsRecordStorage<?>) datastoreFactory.createRecordStorage(DifferentTestEntity.class);
-        assertNotEquals(storage.getKind(), differentStorage.getKind());
-    }
+//    @Test
+//    public void create_separate_record_storage_per_state_type() {
+//        final DsRecordStorage<?> storage = (DsRecordStorage<?>) datastoreFactory.createRecordStorage(TestEntity.class);
+//        final DsRecordStorage<?> differentStorage =
+//                (DsRecordStorage<?>) datastoreFactory.createRecordStorage(DifferentTestEntity.class);
+//        assertNotEquals(storage.getKind(), differentStorage.getKind());
+//    }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -143,7 +143,7 @@ public class DatastoreWrapperShould {
             for (int i = 0; i < n; i++) {
                 final Any message = Any.getDefaultInstance();
                 final DatastoreRecordId recordId = new DatastoreRecordId(String.format("record-%s", i));
-                final Key key = DsIdentifiers.keyFor(wrapper, GENERIC_ENTITY_KIND, recordId);
+                final Key key = DsIdentifiers.keyFor(wrapper, Kind.of(GENERIC_ENTITY_KIND), recordId);
                 final Entity entity = Entities.messageToEntity(message, key);
                 result.put(key, entity);
             }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsProjectionStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsProjectionStorageShould.java
@@ -23,10 +23,15 @@ package org.spine3.server.storage.datastore;
 import org.junit.After;
 import org.junit.Test;
 import org.spine3.base.Identifiers;
+import org.spine3.base.Version;
+import org.spine3.protobuf.AnyPacker;
+import org.spine3.protobuf.Timestamps2;
+import org.spine3.server.entity.EntityRecord;
 import org.spine3.server.projection.Projection;
 import org.spine3.server.projection.ProjectionStorage;
 import org.spine3.server.projection.ProjectionStorageShould;
 import org.spine3.test.projection.Project;
+import org.spine3.testdata.Sample;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -36,6 +41,16 @@ import static org.junit.Assert.assertNotNull;
 public class DsProjectionStorageShould extends ProjectionStorageShould<String> {
     private static final TestDatastoreStorageFactory datastoreFactory =
             TestDatastoreStorageFactory.getDefaultInstance();
+
+    @SuppressWarnings({"MagicNumber", "MethodDoesntCallSuperMethod"})
+    @Override
+    protected EntityRecord newStorageRecord() {
+        return EntityRecord.newBuilder()
+                .setState(
+                        AnyPacker.pack(Sample.messageOfType(Project.class)))
+                .setVersion(Version.newBuilder().setNumber(42).setTimestamp(Timestamps2.getCurrentTime()))
+                .build();
+    }
 
     @After
     public void tearDownTest() {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/KindShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/KindShould.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Any;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.junit.Test;
+import org.spine3.type.TypeName;
+import org.spine3.type.TypeUrl;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class KindShould {
+
+    @Test
+    public void be_null_safe() {
+        new NullPointerTester()
+                .setDefault(TypeUrl.class, TypeUrl.from(Any.getDescriptor()))
+                .setDefault(Descriptors.Descriptor.class, Any.getDescriptor())
+                .setDefault(Message.class, Any.getDefaultInstance())
+                .setDefault(TypeName.class, TypeName.of(Any.class))
+                .testStaticMethods(Kind.class, NullPointerTester.Visibility.PACKAGE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void not_accept_forbidden_prefix() {
+        final String invalidKind = "__my.invalid.type";
+        Kind.of(invalidKind);
+    }
+
+    @Test
+    public void construct_from_string() {
+        final String type = "my.custom.type";
+        final Kind kind = Kind.of(type);
+        assertEquals(type, kind.getValue());
+    }
+
+    @Test
+    public void construct_from_TypeUrl() {
+        final Descriptors.Descriptor descriptor = Any.getDescriptor();
+        final TypeUrl type = TypeUrl.from(descriptor);
+        final Kind kind = Kind.of(type);
+        assertEquals(descriptor.getFullName(), kind.getValue());
+        assertEquals(type.getTypeName(), kind.getValue());
+    }
+
+    @Test
+    public void construct_from_descriptor() {
+        final Descriptors.Descriptor descriptor = Any.getDescriptor();
+        final Kind kind = Kind.of(descriptor);
+        assertEquals(descriptor.getFullName(), kind.getValue());
+    }
+
+    @Test
+    public void construct_from_Message() {
+        final Message message = Any.getDefaultInstance();
+        final Kind kind = Kind.of(message);
+        assertEquals(message.getDescriptorForType().getFullName(), kind.getValue());
+    }
+
+    @Test
+    public void construct_from_TypeName() {
+        final Descriptors.Descriptor descriptor = Any.getDescriptor();
+        final TypeName type = TypeName.from(descriptor);
+        final Kind kind = Kind.of(type);
+        assertEquals(descriptor.getFullName(), kind.getValue());
+        assertEquals(type.value(), kind.getValue());
+    }
+}


### PR DESCRIPTION
Main changes:
 - Each `RecordStorage` has its own `kind` (determined by the record type name)
 - `DsPropertyStorage` uses `Descriptor` to store the values of single type under a single `kind`
 - `DsStandStorage` now uses an instance of `DsStandStorageDelegate extends DsRecordStorage<AggregateStateId>` to delegate its operations.

Now instead of storing the type URL of the record as a field, we store each the `EntityRecord` type under its own type.
Example:

```
class ProjectProjection extends Projection<ProjectId, Project> { /* ... */ }

class TaskProjection extends Projection<TaskId, Task> { /* ... */ }

class ForeignProjectProjection extends Projection<String, Project> { /* ... */ }
```

In this case, records generated from `ProjectProjection` and `ForeignProjectProjection` will be stored under a single Datastore `kind` and the ones from `TaskProjection` will be stored in a separate `kind`.

The `kind` name corresponds the `Entity`'s state type name (defined in protobuf).
