### PR TITLE
Multitenancy support

### DIFF
--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -32,7 +32,7 @@ import org.spine3.server.projection.ProjectionStorage;
 import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.StorageFactory;
-import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
+import org.spine3.server.storage.datastore.dsnative.DsNamespaces;
 import org.spine3.server.storage.datastore.type.DatastoreColumnType;
 import org.spine3.server.storage.datastore.type.DatastoreTypeRegistry;
 import org.spine3.type.TypeUrl;
@@ -85,7 +85,7 @@ public class DatastoreStorageFactory implements StorageFactory {
 
     private void initDatastoreWrapper(Datastore datastore) {
         checkState(this.getDatastore() == null, "Datastore is already initialized");
-        final DatastoreWrapper wrapped = DatastoreWrapper.wrap(datastore, NamespaceSupplier.instanceFor(this));
+        final DatastoreWrapper wrapped = DatastoreWrapper.wrap(datastore, DsNamespaces.getSupplierFor(this));
         this.setDatastore(wrapped);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -32,6 +32,7 @@ import org.spine3.server.projection.ProjectionStorage;
 import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.StorageFactory;
+import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
 import org.spine3.server.storage.datastore.type.DatastoreColumnType;
 import org.spine3.server.storage.datastore.type.DatastoreTypeRegistry;
 import org.spine3.type.TypeUrl;
@@ -47,6 +48,7 @@ import static org.spine3.server.reflect.Classes.getGenericParameterType;
  *
  * @author Alexander Litus
  * @author Mikhail Mikhaylov
+ * @author Dmytro Dashenkov
  */
 @SuppressWarnings("WeakerAccess") // Part of API
 public class DatastoreStorageFactory implements StorageFactory {
@@ -85,7 +87,7 @@ public class DatastoreStorageFactory implements StorageFactory {
     @VisibleForTesting
     protected void initDatastoreWrapper(Datastore datastore) {
         checkState(this.getDatastore() == null, "Datastore is already initialized");
-        final DatastoreWrapper wrapped = DatastoreWrapper.wrap(datastore);
+        final DatastoreWrapper wrapped = DatastoreWrapper.wrap(datastore, NamespaceSupplier.instanceFor(this));
         this.setDatastore(wrapped);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -264,6 +264,7 @@ public class DatastoreStorageFactory implements StorageFactory {
         }
 
         private static void checkHasNoNamespace(Datastore datastore) {
+            checkNotNull(datastore);
             final DatastoreOptions options = datastore.getOptions();
             final String namespace = options.getNamespace();
             checkArgument(isNullOrEmpty(namespace),

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -21,6 +21,7 @@
 package org.spine3.server.storage.datastore;
 
 import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
@@ -37,8 +38,10 @@ import org.spine3.server.storage.datastore.type.DatastoreColumnType;
 import org.spine3.server.storage.datastore.type.DatastoreTypeRegistry;
 import org.spine3.type.TypeUrl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.spine3.server.entity.Entity.GenericParameter.ID;
 import static org.spine3.server.entity.Entity.GenericParameter.STATE;
 import static org.spine3.server.reflect.Classes.getGenericParameterType;
@@ -217,6 +220,7 @@ public class DatastoreStorageFactory implements StorageFactory {
          * @return self for method chaining
          */
         public Builder setDatastore(Datastore datastore) {
+            checkHasNoNamespace(datastore);
             this.datastore = datastore;
             return this;
         }
@@ -256,6 +260,13 @@ public class DatastoreStorageFactory implements StorageFactory {
         public DatastoreStorageFactory build() {
             checkNotNull(datastore);
             return new DatastoreStorageFactory(this);
+        }
+
+        private static void checkHasNoNamespace(Datastore datastore) {
+            final DatastoreOptions options = datastore.getOptions();
+            final String namespace = options.getNamespace();
+            checkArgument(isNullOrEmpty(namespace),
+                          "Datastore namespace should not be set explicitly.");
         }
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.server.storage.datastore.dsnative.Namespace;
 import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
 
@@ -72,7 +73,7 @@ public class DatastoreWrapper {
     private static final int MAX_KEYS_PER_READ_REQUEST = 1000;
     private static final int MAX_ENTITIES_PER_WRITE_REQUEST = 500;
 
-    private static final Map<String, KeyFactory> keyFactories = new HashMap<>();
+    private static final Map<Kind, KeyFactory> keyFactories = new HashMap<>();
 
     private final Datastore datastore;
     private Transaction activeTransaction;
@@ -356,7 +357,7 @@ public class DatastoreWrapper {
      * @param kind kind of {@link Entity} to generate keys for
      * @return an instance of {@link KeyFactory} for given kind
      */
-    public KeyFactory getKeyFactory(String kind) {
+    public KeyFactory getKeyFactory(Kind kind) {
         KeyFactory keyFactory = keyFactories.get(kind);
         if (keyFactory == null) {
             keyFactory = initKeyFactory(kind);
@@ -371,9 +372,9 @@ public class DatastoreWrapper {
         return datastore;
     }
 
-    private KeyFactory initKeyFactory(String kind) {
+    private KeyFactory initKeyFactory(Kind kind) {
         final KeyFactory keyFactory = datastore.newKeyFactory()
-                                               .setKind(kind);
+                                               .setKind(kind.getValue());
         keyFactories.put(kind, keyFactory);
         return keyFactory;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -80,6 +80,12 @@ public class DatastoreWrapper {
 
     private final NamespaceSupplier namespaceSupplier;
 
+    /**
+     * Creates a new instance of {@code DatastoreWrapper}.
+     *
+     * @param datastore         {@link Datastore} to wrap
+     * @param namespaceSupplier an instance of {@link NamespaceSupplier} to use in the queries and keys
+     */
     protected DatastoreWrapper(Datastore datastore, NamespaceSupplier namespaceSupplier) {
         this.namespaceSupplier = namespaceSupplier;
         this.datastore = datastore;
@@ -89,7 +95,8 @@ public class DatastoreWrapper {
     /**
      * Wraps {@link Datastore} into an instance of {@code DatastoreWrapper} and returns the instance.
      *
-     * @param datastore {@link Datastore} to wrap
+     * @param datastore         {@link Datastore} to wrap
+     * @param namespaceSupplier an instance of {@link NamespaceSupplier} to use in the queries and keys
      * @return new instance of {@code DatastoreWrapper}
      */
     @SuppressWarnings("WeakerAccess") // Part of API
@@ -202,8 +209,8 @@ public class DatastoreWrapper {
     public List<Entity> read(StructuredQuery<Entity> query) {
         final Namespace namespace = namespaceSupplier.getNamespace();
         final StructuredQuery<Entity> queryWithNamespace = query.toBuilder()
-                                                          .setNamespace(namespace.getValue())
-                                                          .build();
+                                                                .setNamespace(namespace.getValue())
+                                                                .build();
         QueryResults<Entity> queryResults = actor.run(queryWithNamespace);
         final List<Entity> resultsAsList = newLinkedList();
 
@@ -344,9 +351,7 @@ public class DatastoreWrapper {
     }
 
     /**
-     * Retrieves an instance of {@link KeyFactory} unique for given Kind of data.
-     *
-     * <p>Retrieved instances are the same across all instances of {@code DatastoreWrapper}.
+     * Retrieves an instance of {@link KeyFactory} unique for given Kind of data regarding the current namespace.
      *
      * @param kind kind of {@link Entity} to generate keys for
      * @return an instance of {@link KeyFactory} for given kind
@@ -356,6 +361,8 @@ public class DatastoreWrapper {
         if (keyFactory == null) {
             keyFactory = initKeyFactory(kind);
         }
+        final Namespace namespace = namespaceSupplier.getNamespace();
+        keyFactory.setNamespace(namespace.getValue());
 
         return keyFactory;
     }
@@ -365,10 +372,8 @@ public class DatastoreWrapper {
     }
 
     private KeyFactory initKeyFactory(String kind) {
-        final Namespace namespace = namespaceSupplier.getNamespace();
         final KeyFactory keyFactory = datastore.newKeyFactory()
-                                               .setKind(kind)
-                                               .setNamespace(namespace.getValue());
+                                               .setKind(kind);
         keyFactories.put(kind, keyFactory);
         return keyFactory;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -39,6 +39,7 @@ import com.google.cloud.datastore.StructuredQuery;
 import com.google.cloud.datastore.Transaction;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -46,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.server.storage.datastore.dsnative.Namespace;
-import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -80,15 +80,16 @@ public class DatastoreWrapper {
     private Transaction activeTransaction;
     private DatastoreReaderWriter actor;
 
-    private final NamespaceSupplier namespaceSupplier;
+    private final Supplier<Namespace> namespaceSupplier;
 
     /**
      * Creates a new instance of {@code DatastoreWrapper}.
      *
      * @param datastore         {@link Datastore} to wrap
-     * @param namespaceSupplier an instance of {@link NamespaceSupplier} to use in the queries and keys
+     * @param namespaceSupplier an instance of {@link Supplier Supplier<Namespace>} to get the
+     *                          namespaces for the queries from
      */
-    protected DatastoreWrapper(Datastore datastore, NamespaceSupplier namespaceSupplier) {
+    protected DatastoreWrapper(Datastore datastore, Supplier<Namespace> namespaceSupplier) {
         this.namespaceSupplier = namespaceSupplier;
         this.datastore = datastore;
         this.actor = datastore;
@@ -98,11 +99,12 @@ public class DatastoreWrapper {
      * Wraps {@link Datastore} into an instance of {@code DatastoreWrapper} and returns the instance.
      *
      * @param datastore         {@link Datastore} to wrap
-     * @param namespaceSupplier an instance of {@link NamespaceSupplier} to use in the queries and keys
+     * @param namespaceSupplier an instance of {@link Supplier Supplier<Namespace>} to get the
+     *                          namespaces for the queries from
      * @return new instance of {@code DatastoreWrapper}
      */
     @SuppressWarnings("WeakerAccess") // Part of API
-    protected static DatastoreWrapper wrap(Datastore datastore, NamespaceSupplier namespaceSupplier) {
+    protected static DatastoreWrapper wrap(Datastore datastore, Supplier<Namespace> namespaceSupplier) {
         return new DatastoreWrapper(datastore, namespaceSupplier);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -209,7 +209,7 @@ public class DatastoreWrapper {
      * @see DatastoreReader#run(Query)
      */
     public List<Entity> read(StructuredQuery<Entity> query) {
-        final Namespace namespace = namespaceSupplier.getNamespace();
+        final Namespace namespace = namespaceSupplier.get();
         final StructuredQuery<Entity> queryWithNamespace = query.toBuilder()
                                                                 .setNamespace(namespace.getValue())
                                                                 .build();
@@ -245,7 +245,7 @@ public class DatastoreWrapper {
      * @param table kind (a.k.a. type, table, etc.) of the records to delete
      */
     void dropTable(String table) {
-        final Namespace namespace = namespaceSupplier.getNamespace();
+        final Namespace namespace = namespaceSupplier.get();
         final StructuredQuery<Entity> query = Query.newEntityQueryBuilder()
                                                    .setNamespace(namespace.getValue())
                                                    .setKind(table)
@@ -363,7 +363,7 @@ public class DatastoreWrapper {
         if (keyFactory == null) {
             keyFactory = initKeyFactory(kind);
         }
-        final Namespace namespace = namespaceSupplier.getNamespace();
+        final Namespace namespace = namespaceSupplier.get();
         keyFactory.setNamespace(namespace.getValue());
 
         return keyFactory;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -437,7 +437,7 @@ public class DatastoreWrapper {
 
     private DsNamespaceValidator namespaceValidator() {
         if (namespaceValidator == null) {
-            namespaceValidator = new DsNamespaceValidator(this);
+            namespaceValidator = new DsNamespaceValidator(getDatastore());
         }
         return namespaceValidator;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsAggregateStorage.java
@@ -37,6 +37,7 @@ import org.spine3.protobuf.Timestamps2;
 import org.spine3.server.aggregate.AggregateEventRecord;
 import org.spine3.server.aggregate.AggregateStorage;
 import org.spine3.server.entity.LifecycleFlags;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.type.TypeName;
 import org.spine3.type.TypeUrl;
 
@@ -151,13 +152,12 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         checkNotNull(id);
 
         final String idString = Stringifiers.toString(id);
-        final Query<Entity> query = Query.newEntityQueryBuilder()
-                                         .setKind(stateTypeName.value())
-                                         .setFilter(
-                                                 StructuredQuery.PropertyFilter.eq(
-                                                         aggregate_id.toString(),
-                                                         idString))
-                                         .build();
+        final StructuredQuery<Entity> query = Query.newEntityQueryBuilder()
+                                                   .setKind(stateTypeName.value())
+                                                   .setFilter(StructuredQuery.PropertyFilter.eq(
+                                                           aggregate_id.toString(),
+                                                           idString))
+                                                   .build();
         final List<Entity> eventEntities = datastore.read(query);
         if (eventEntities.isEmpty()) {
             return Collections.emptyIterator();
@@ -193,9 +193,9 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
     }
 
     private Collection<Entity> getEntityStates() {
-        final Query<Entity> query = Query.newEntityQueryBuilder()
-                                         .setKind(AGGREGATE_LIFECYCLE_KIND.value())
-                                         .build();
+        final StructuredQuery<Entity> query = Query.newEntityQueryBuilder()
+                                                   .setKind(AGGREGATE_LIFECYCLE_KIND.value())
+                                                   .build();
         return datastore.read(query);
     }
 
@@ -272,9 +272,9 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
     public Iterator<I> index() {
         checkNotClosed();
 
-        final Query<Entity> allQuery = Query.newEntityQueryBuilder()
-                                            .setKind(stateTypeName.value())
-                                            .build();
+        final StructuredQuery<Entity> allQuery = Query.newEntityQueryBuilder()
+                                                      .setKind(stateTypeName.value())
+                                                      .build();
         final List<Entity> allRecords = datastore.read(allQuery);
         final Iterator<I> index = Iterators.transform(allRecords.iterator(), new IndexExtractror<>(idClass));
         return index;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsIdentifiers.java
@@ -27,6 +27,7 @@ import org.spine3.base.CommandId;
 import org.spine3.base.Event;
 import org.spine3.base.EventId;
 import org.spine3.server.stand.AggregateStateId;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.spine3.base.Identifiers.idToString;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsIdentifiers.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsIdentifiers.java
@@ -55,7 +55,7 @@ public class DsIdentifiers {
      * @return the Datastore {@code Key} instance
      */
     static Key keyFor(DatastoreWrapper datastore, Kind kind, DatastoreRecordId recordId) {
-        final KeyFactory keyFactory = datastore.getKeyFactory(kind.getValue());
+        final KeyFactory keyFactory = datastore.getKeyFactory(kind);
         final Key key = keyFactory.newKey(recordId.getValue());
 
         return key;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsPropertyStorage.java
@@ -27,6 +27,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
 import org.spine3.protobuf.AnyPacker;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.type.TypeUrl;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsRecordStorage.java
@@ -43,6 +43,7 @@ import org.spine3.server.entity.storage.ColumnType;
 import org.spine3.server.entity.storage.ColumnTypeRegistry;
 import org.spine3.server.entity.storage.EntityRecordWithColumns;
 import org.spine3.server.storage.RecordStorage;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.server.storage.datastore.type.DatastoreColumnType;
 import org.spine3.type.TypeUrl;
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DsStandStorageDelegate.java
@@ -37,6 +37,7 @@ import org.spine3.server.entity.FieldMasks;
 import org.spine3.server.entity.storage.ColumnTypeRegistry;
 import org.spine3.server.entity.storage.EntityRecordWithColumns;
 import org.spine3.server.stand.AggregateStateId;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.server.storage.datastore.type.DatastoreColumnType;
 import org.spine3.type.TypeUrl;
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/Indexes.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/Indexes.java
@@ -26,6 +26,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/DsNamespaceValidator.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/DsNamespaceValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+import org.spine3.server.storage.datastore.DatastoreWrapper;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class DsNamespaceValidator {
+
+    private final NamespaceAccess namespaceAccess;
+
+    public DsNamespaceValidator(DatastoreWrapper datastore) {
+        this.namespaceAccess = new NamespaceAccess(datastore);
+    }
+
+    public void validate(Namespace namespace) {
+        checkNotNull(namespace);
+        final boolean found = namespaceAccess.contains(namespace);
+        checkState(found, "Namespace %s could not be found in the Datastore.", namespace);
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/DsNamespaceValidator.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/DsNamespaceValidator.java
@@ -20,7 +20,7 @@
 
 package org.spine3.server.storage.datastore.dsnative;
 
-import org.spine3.server.storage.datastore.DatastoreWrapper;
+import com.google.cloud.datastore.Datastore;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -32,13 +32,13 @@ public class DsNamespaceValidator {
 
     private final NamespaceAccess namespaceAccess;
 
-    public DsNamespaceValidator(DatastoreWrapper datastore) {
+    public DsNamespaceValidator(Datastore datastore) {
         this.namespaceAccess = new NamespaceAccess(datastore);
     }
 
     public void validate(Namespace namespace) {
         checkNotNull(namespace);
-        final boolean found = namespaceAccess.contains(namespace);
+        final boolean found = namespaceAccess.exists(namespace);
         checkState(found, "Namespace %s could not be found in the Datastore.", namespace);
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/DsNamespaces.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/DsNamespaces.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+import com.google.common.base.Supplier;
+import org.spine3.annotations.Internal;
+import org.spine3.server.storage.datastore.DatastoreStorageFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+@Internal
+public class DsNamespaces {
+
+    private DsNamespaces() {
+        // Avoid initializing of a utility class
+    }
+
+    public static Supplier<Namespace> getSupplierFor(DatastoreStorageFactory factory) {
+        checkNotNull(factory);
+        final Supplier<Namespace> result = NamespaceSupplier.instanceFor(factory);
+        return result;
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Kind.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Kind.java
@@ -41,10 +41,23 @@ public final class Kind {
             "Datastore kind cannot start with \"__\". See https://cloud.google.com/datastore/docs/concepts/entities#kinds_and_identifiers for more info.";
     private static final String FORBIDDEN_PREFIX = "__";
 
+    private static final String NAMESPACE_KIND = "__namespace__";
+
     private final String value;
 
     private Kind(String value) {
         this.value = checkValidKind(value);
+    }
+
+    /**
+     * Creates a new instance of {@code Kind} representing an ancillary Datastore kind.
+     *
+     * @param value the name of the kind
+     * @param ancillary the flag showing that the {@code Kind} is ancillary; must be set to {@code true}
+     */
+    private Kind(String value, boolean ancillary) {
+        checkArgument(ancillary);
+        this.value = value;
     }
 
     public static Kind of(String value) {
@@ -65,6 +78,10 @@ public final class Kind {
 
     public static Kind of(TypeName typeName) {
         return new Kind(typeName.value());
+    }
+
+    static Kind ofNamespace() {
+        return new Kind(NAMESPACE_KIND, true);
     }
 
     public String getValue() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Kind.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Kind.java
@@ -20,6 +20,7 @@
 
 package org.spine3.server.storage.datastore.dsnative;
 
+import com.google.common.base.Objects;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
 import org.spine3.type.TypeName;
@@ -74,5 +75,22 @@ public final class Kind {
         checkNotNull(kind);
         checkArgument(!kind.startsWith(FORBIDDEN_PREFIX), INVALID_KIND_ERROR_MESSAGE);
         return kind;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Kind kind = (Kind) o;
+        return Objects.equal(getValue(), kind.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getValue());
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Kind.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Kind.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.spine3.server.storage.datastore;
+package org.spine3.server.storage.datastore.dsnative;
 
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/MultitenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/MultitenantNamespaceSupplier.java
@@ -29,10 +29,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
 /**
+ * A {@link NamespaceSupplier} for multitenant storage factories.
+ *
  * @author Dmytro Dashenkov
  */
 final class MultitenantNamespaceSupplier extends NamespaceSupplier {
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return the {@link Namespace} representing the current tenant {@link TenantId ID}
+     */
     @Override
     public Namespace getNamespace() {
         final TenantIdRetriever retriever = TenantIdRetriever.instance();
@@ -43,6 +50,9 @@ final class MultitenantNamespaceSupplier extends NamespaceSupplier {
         return result;
     }
 
+    /**
+     * @return a human-friendly string representation of the {@link TenantId}
+     */
     private static String tenantIdToSignificantString(TenantId id) {
         final TenantId.KindCase kindCase = id.getKindCase();
         switch (kindCase) {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/MultitenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/MultitenantNamespaceSupplier.java
@@ -24,11 +24,8 @@ import org.spine3.server.tenant.TenantFunction;
 import org.spine3.users.TenantId;
 
 import javax.annotation.Nullable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.String.format;
 
 /**
  * A {@link NamespaceSupplier} for multitenant storage factories.
@@ -37,55 +34,17 @@ import static java.lang.String.format;
  */
 final class MultitenantNamespaceSupplier extends NamespaceSupplier {
 
-    private static final Pattern AT_SYMBOL_PATTERN = Pattern.compile("@", Pattern.LITERAL);
-    private static final String AT_SYMBOL_REPLACEMENT = "-at-";
-
     /**
      * {@inheritDoc}
      *
      * @return the {@link Namespace} representing the current tenant {@link TenantId ID}
      */
     @Override
-    public Namespace getNamespace() {
+    public Namespace get() {
         final TenantIdRetriever retriever = new TenantIdRetriever();
         final TenantId tenantId = retriever.execute();
         checkNotNull(tenantId);
-        final String stringTenantId = tenantIdToSignificantString(tenantId);
-        final Namespace result = Namespace.of(stringTenantId);
-        return result;
-    }
-
-    /**
-     * @return a human-friendly string representation of the {@link TenantId}
-     */
-    private static String tenantIdToSignificantString(TenantId id) {
-        final TenantId.KindCase kindCase = id.getKindCase();
-        final String result;
-        switch (kindCase) {
-            case DOMAIN:
-                result = id.getDomain()
-                           .getValue();
-                break;
-            case EMAIL:
-                result = id.getEmail()
-                           .getValue();
-                break;
-            case VALUE:
-                result = id.getValue();
-                break;
-            case KIND_NOT_SET:
-            default:
-                throw new IllegalStateException(format("Tenant ID is not set. Kind of TenantId is %s.",
-                                                       kindCase.toString()));
-        }
-
-        final String escapedResult = escapeIllegalCharacters(result);
-        return escapedResult;
-    }
-
-    private static String escapeIllegalCharacters(String condidateNamespace) {
-        final String result = AT_SYMBOL_PATTERN.matcher(condidateNamespace)
-                                               .replaceAll(Matcher.quoteReplacement(AT_SYMBOL_REPLACEMENT));
+        final Namespace result = Namespace.of(tenantId);
         return result;
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/MultitenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/MultitenantNamespaceSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+final class MultitenantNamespaceSupplier extends NamespaceSupplier {
+
+    MultitenantNamespaceSupplier() {
+    }
+
+    @Override
+    public Namespace getNamespace() {
+        // TODO:2017-04-07:dmytro.dashenkov: Namespace based of the tenant ID.
+        return Namespace.of("???");
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
@@ -21,7 +21,13 @@
 package org.spine3.server.storage.datastore.dsnative;
 
 /**
+ * A value object representing the Datastore
+ * <a href="https://cloud.google.com/datastore/docs/concepts/multitenancy">namespace</a>.
+ *
+ * <p>The primary usage of the namespaces is multitenancy.
+ *
  * @author Dmytro Dashenkov
+ * @see NamespaceSupplier
  */
 public final class Namespace {
 
@@ -31,7 +37,7 @@ public final class Namespace {
         this.value = value;
     }
 
-    public static Namespace of(String datastoreNamespace) {
+    static Namespace of(String datastoreNamespace) {
         return new Namespace(datastoreNamespace);
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
@@ -20,6 +20,14 @@
 
 package org.spine3.server.storage.datastore.dsnative;
 
+import com.google.common.base.Objects;
+import org.spine3.users.TenantId;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
 /**
  * A value object representing the Datastore
  * <a href="https://cloud.google.com/datastore/docs/concepts/multitenancy">namespace</a>.
@@ -31,17 +39,95 @@ package org.spine3.server.storage.datastore.dsnative;
  */
 public final class Namespace {
 
+    private static final Pattern AT_SYMBOL_PATTERN = Pattern.compile("@", Pattern.LITERAL);
+    private static final String AT_SYMBOL_REPLACEMENT = "-at-";
+
     private final String value;
 
     private Namespace(String value) {
         this.value = value;
     }
 
-    static Namespace of(String datastoreNamespace) {
-        return new Namespace(datastoreNamespace);
+    /**
+     * Creates new instance of {@code Namespace} from the given string.
+     *
+     * @param datastoreNamespace a string representing the datastore namespace
+     * @return new instance of {@code Namespace}
+     */
+    public static Namespace of(String datastoreNamespace) {
+        return new Namespace(
+                escapeIllegalCharacters(datastoreNamespace));
     }
 
+    /**
+     * Creates new instance of {@code Namespace} from the given {@link TenantId}.
+     *
+     * @param tenantId the {@link TenantId} to create the {@code Namespace} from
+     * @return new instance of {@code Namespace}
+     */
+    static Namespace of(TenantId tenantId) {
+        final String idStringValue = tenantIdToSignificantString(tenantId);
+        return of(idStringValue);
+    }
+
+    /**
+     * @return a human-friendly string representation of the {@link TenantId}
+     */
+    private static String tenantIdToSignificantString(TenantId id) {
+        final TenantId.KindCase kindCase = id.getKindCase();
+        final String result;
+        switch (kindCase) {
+            case DOMAIN:
+                result = id.getDomain()
+                           .getValue();
+                break;
+            case EMAIL:
+                result = id.getEmail()
+                           .getValue();
+                break;
+            case VALUE:
+                result = id.getValue();
+                break;
+            case KIND_NOT_SET:
+            default:
+                throw new IllegalStateException(format("Tenant ID is not set. Kind of TenantId is %s.",
+                                                       kindCase.toString()));
+        }
+        return result;
+    }
+
+    private static String escapeIllegalCharacters(String candidateNamespace) {
+        final String result = AT_SYMBOL_PATTERN.matcher(candidateNamespace)
+                                               .replaceAll(Matcher.quoteReplacement(AT_SYMBOL_REPLACEMENT));
+        return result;
+    }
+
+    /**
+     * @return a string value of this {@code Namespace}
+     */
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Namespace namespace = (Namespace) o;
+        return Objects.equal(getValue(), namespace.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getValue());
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public final class Namespace {
+
+    private final String value;
+
+    private Namespace(String value) {
+        this.value = value;
+    }
+
+    public static Namespace of(String datastoreNamespace) {
+        return new Namespace(datastoreNamespace);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/Namespace.java
@@ -54,7 +54,7 @@ public final class Namespace {
      * @param datastoreNamespace a string representing the datastore namespace
      * @return new instance of {@code Namespace}
      */
-    public static Namespace of(String datastoreNamespace) {
+    static Namespace of(String datastoreNamespace) {
         return new Namespace(
                 escapeIllegalCharacters(datastoreNamespace));
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceAccess.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceAccess.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.EntityQuery;
+import com.google.cloud.datastore.Query;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import org.spine3.server.storage.datastore.DatastoreWrapper;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+class NamespaceAccess {
+
+    private static final Kind NAMESPACE_KIND = Kind.ofNamespace();
+    private static final Function<Entity, Namespace> NAMESPACE_UNPACKER =
+            new Function<Entity, Namespace>() {
+                @Nullable
+                @Override
+                public Namespace apply(@Nullable Entity entity) {
+                    checkNotNull(entity);
+
+                    return null;
+                }
+            };
+
+    private final DatastoreWrapper datastore;
+
+    private final Set<Namespace> cache = new HashSet<>();
+
+    NamespaceAccess(DatastoreWrapper datastore) {
+        this.datastore = datastore;
+    }
+
+    boolean contains(Namespace namespace) {
+        checkNotNull(namespace);
+
+        final boolean cachedNamespace = cache.contains(namespace);
+        if (cachedNamespace) {
+            return true;
+        }
+        cache.clear();
+
+        final EntityQuery query = Query.newEntityQueryBuilder()
+                                       .setKind(NAMESPACE_KIND.getValue())
+                                       .build();
+        // TODO:2017-04-11:dmytro.dashenkov: Recursive call here. Fix this.
+        final List<Entity> existingNamespaces = datastore.read(query);
+        final Collection<Namespace> extractedNamespaces =
+                Collections2.transform(existingNamespaces, NAMESPACE_UNPACKER);
+        cache.addAll(extractedNamespaces);
+        final boolean result = cache.contains(namespace);
+        return result;
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
@@ -26,10 +26,20 @@ import org.spine3.server.storage.datastore.DatastoreStorageFactory;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
+ * A factory for the {@linkplain Namespace namespaces}, based on the current multitenancy configuration and
+ * {@linkplain org.spine3.users.TenantId tenant ID}.
+ *
  * @author Dmytro Dashenkov
  */
 public abstract class NamespaceSupplier {
 
+    /**
+     * Obtains an instance of {@code NamespaceSupplier} for the passed
+     * {@linkplain DatastoreStorageFactory storage factory}.
+     *
+     * @param factory the {@linkplain DatastoreStorageFactory storage factory} to return a supplier for
+     * @see org.spine3.server.storage.StorageFactory#isMultitenant
+     */
     public static NamespaceSupplier instanceFor(DatastoreStorageFactory factory) {
         checkNotNull(factory);
         if (factory.isMultitenant()) {
@@ -47,6 +57,13 @@ public abstract class NamespaceSupplier {
     NamespaceSupplier() {
     }
 
+    /**
+     * Generates a {@link Namespace} based on the current {@linkplain org.spine3.users.TenantId tenant ID}.
+     *
+     * @return an instance of {@link Namespace} representing either the current tenant ID or an empty string if
+     * the {@linkplain DatastoreStorageFactory storage factory} passed upon the initialization is configured to be
+     * single tenant
+     */
     public abstract Namespace getNamespace();
 
     private enum Singleton {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
@@ -50,8 +50,13 @@ public abstract class NamespaceSupplier {
     }
 
     @VisibleForTesting
-    public static NamespaceSupplier constant() {
+    static NamespaceSupplier constant() {
         return Singleton.INSTANCE.singleTenant;
+    }
+
+    @VisibleForTesting
+    static NamespaceSupplier multitenant() {
+        return Singleton.INSTANCE.multipleTenant;
     }
 
     NamespaceSupplier() {

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
@@ -21,17 +21,18 @@
 package org.spine3.server.storage.datastore.dsnative;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
 import org.spine3.server.storage.datastore.DatastoreStorageFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A factory for the {@linkplain Namespace namespaces}, based on the current multitenancy configuration and
+ * A supplier for the {@linkplain Namespace namespaces}, based on the current multitenancy configuration and
  * {@linkplain org.spine3.users.TenantId tenant ID}.
  *
  * @author Dmytro Dashenkov
  */
-public abstract class NamespaceSupplier {
+public abstract class NamespaceSupplier implements Supplier<Namespace> {
 
     /**
      * Obtains an instance of {@code NamespaceSupplier} for the passed
@@ -69,7 +70,8 @@ public abstract class NamespaceSupplier {
      * the {@linkplain DatastoreStorageFactory storage factory} passed upon the initialization is configured to be
      * single tenant
      */
-    public abstract Namespace getNamespace();
+    @Override
+    public abstract Namespace get();
 
     private enum Singleton {
         INSTANCE;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Dmytro Dashenkov
  */
-public abstract class NamespaceSupplier implements Supplier<Namespace> {
+abstract class NamespaceSupplier implements Supplier<Namespace> {
 
     /**
      * Obtains an instance of {@code NamespaceSupplier} for the passed
@@ -41,7 +41,7 @@ public abstract class NamespaceSupplier implements Supplier<Namespace> {
      * @param factory the {@linkplain DatastoreStorageFactory storage factory} to return a supplier for
      * @see org.spine3.server.storage.StorageFactory#isMultitenant
      */
-    public static NamespaceSupplier instanceFor(DatastoreStorageFactory factory) {
+    static NamespaceSupplier instanceFor(DatastoreStorageFactory factory) {
         checkNotNull(factory);
         if (factory.isMultitenant()) {
             return Singleton.INSTANCE.singleTenant;
@@ -58,9 +58,6 @@ public abstract class NamespaceSupplier implements Supplier<Namespace> {
     @VisibleForTesting
     static NamespaceSupplier multitenant() {
         return Singleton.INSTANCE.multipleTenant;
-    }
-
-    NamespaceSupplier() {
     }
 
     /**

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/NamespaceSupplier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.spine3.server.storage.datastore.DatastoreStorageFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public abstract class NamespaceSupplier {
+
+    public static NamespaceSupplier instanceFor(DatastoreStorageFactory factory) {
+        checkNotNull(factory);
+        if (factory.isMultitenant()) {
+            return Singleton.INSTANCE.singleTenant;
+        } else {
+            return Singleton.INSTANCE.multipleTenant;
+        }
+    }
+
+    @VisibleForTesting
+    public static NamespaceSupplier constant() {
+        return Singleton.INSTANCE.singleTenant;
+    }
+
+    NamespaceSupplier() {
+    }
+
+    public abstract Namespace getNamespace();
+
+    private enum Singleton {
+        INSTANCE;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final NamespaceSupplier singleTenant = new SingleTenantNamespaceSupplier();
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final NamespaceSupplier multipleTenant = new MultitenantNamespaceSupplier();
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
@@ -27,9 +27,6 @@ final class SingleTenantNamespaceSupplier extends NamespaceSupplier {
 
     private static final String DEFAULT_NAMESPACE = "";
 
-    SingleTenantNamespaceSupplier() {
-    }
-
     @Override
     public Namespace getNamespace() {
         return NamespaceSingleton.INSTANCE.value;

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+final class SingleTenantNamespaceSupplier extends NamespaceSupplier {
+
+    private static final String DEFAULT_NAMESPACE = "";
+
+    SingleTenantNamespaceSupplier() {
+    }
+
+    @Override
+    public Namespace getNamespace() {
+        return NamespaceSingleton.INSTANCE.value;
+    }
+
+    private enum NamespaceSingleton {
+        INSTANCE;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final Namespace value = Namespace.of(DEFAULT_NAMESPACE);
+    }
+}

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
@@ -35,7 +35,7 @@ final class SingleTenantNamespaceSupplier extends NamespaceSupplier {
      * @return the {@link Namespace} representing the empty string
      */
     @Override
-    public Namespace getNamespace() {
+    public Namespace get() {
         return NamespaceSingleton.INSTANCE.value;
     }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/dsnative/SingleTenantNamespaceSupplier.java
@@ -21,12 +21,19 @@
 package org.spine3.server.storage.datastore.dsnative;
 
 /**
+ * A {@link NamespaceSupplier} for single-tenant storage factories.
+ *
  * @author Dmytro Dashenkov
  */
 final class SingleTenantNamespaceSupplier extends NamespaceSupplier {
 
     private static final String DEFAULT_NAMESPACE = "";
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return the {@link Namespace} representing the empty string
+     */
     @Override
     public Namespace getNamespace() {
         return NamespaceSingleton.INSTANCE.value;

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryBuilderShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreStorageFactoryBuilderShould.java
@@ -22,6 +22,7 @@ package org.spine3.server.storage.datastore;
 
 import com.google.cloud.datastore.BaseEntity;
 import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.server.entity.storage.Column;
@@ -87,13 +88,22 @@ public class DatastoreStorageFactoryBuilderShould {
         assertNotNull(type);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void ensure_datastore_has_no_namespace() {
+        final DatastoreOptions options = DatastoreOptions.newBuilder()
+                                                         .setNamespace("non-null-or-empty-namespace")
+                                                         .build();
+        DatastoreStorageFactory.newBuilder()
+                               .setDatastore(options.getService());
+    }
+
     private static Datastore mockDatastore() {
-        return mock(Datastore.class);
+        final DatastoreOptions options = DatastoreOptions.getDefaultInstance();
+        return options.getService();
     }
 
     private static <T> Column<T> mockColumn(Class<T> type) {
-        @SuppressWarnings("unchecked")
-        final Column<T> mock = mock(Column.class);
+        @SuppressWarnings("unchecked") final Column<T> mock = mock(Column.class);
         when(mock.getType()).thenReturn(type);
         return mock;
     }

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -55,7 +55,7 @@ public class DatastoreWrapperShould {
     public static void tearDown() {
         final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore(),
                                                                TestNamespaceSuppliers.singleTenant());
-        wrapper.dropTable(NAMESPACE_HOLDER_KIND);
+        //wrapper.dropTable(NAMESPACE_HOLDER_KIND);
     }
 
     @Test

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -55,7 +55,7 @@ public class DatastoreWrapperShould {
     public static void tearDown() {
         final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore(),
                                                                TestNamespaceSuppliers.singleTenant());
-        //wrapper.dropTable(NAMESPACE_HOLDER_KIND);
+        wrapper.dropTable(NAMESPACE_HOLDER_KIND);
     }
 
     @Test

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -25,6 +25,8 @@ import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.protobuf.Any;
 import org.junit.Test;
+import org.spine3.server.storage.datastore.dsnative.Kind;
+import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -43,7 +45,7 @@ public class DatastoreWrapperShould {
 
     @Test
     public void work_with_transactions_if_necessary() {
-        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore());
+        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore(), NamespaceSupplier.constant());
         wrapper.startTransaction();
         assertTrue(wrapper.isTransactionActive());
         wrapper.commitTransaction();
@@ -52,7 +54,7 @@ public class DatastoreWrapperShould {
 
     @Test
     public void rollback_transactions() {
-        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore());
+        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore(), NamespaceSupplier.constant());
         wrapper.startTransaction();
         assertTrue(wrapper.isTransactionActive());
         wrapper.rollbackTransaction();
@@ -61,7 +63,7 @@ public class DatastoreWrapperShould {
 
     @Test(expected = IllegalStateException.class)
     public void fail_to_start_transaction_if_one_is_active() {
-        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore());
+        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore(), NamespaceSupplier.constant());
         try {
             wrapper.startTransaction();
             assertTrue(wrapper.isTransactionActive());
@@ -73,7 +75,7 @@ public class DatastoreWrapperShould {
 
     @Test(expected = IllegalStateException.class)
     public void fail_to_finish_not_active_transaction() {
-        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore());
+        final DatastoreWrapper wrapper = DatastoreWrapper.wrap(Given.testDatastore(), NamespaceSupplier.constant());
         wrapper.startTransaction();
         assertTrue(wrapper.isTransactionActive());
         wrapper.commitTransaction();

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DsRecordStorageShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DsRecordStorageShould.java
@@ -41,6 +41,7 @@ import org.spine3.server.entity.EntityRecord;
 import org.spine3.server.entity.storage.Column;
 import org.spine3.server.entity.storage.EntityRecordWithColumns;
 import org.spine3.server.storage.RecordStorageShould;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.test.storage.Project;
 import org.spine3.test.storage.ProjectId;
 import org.spine3.test.storage.Task;

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/IndexesShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/IndexesShould.java
@@ -22,6 +22,7 @@ package org.spine3.server.storage.datastore;
 
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 
 import static org.mockito.Mockito.mock;
 import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/KindShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/KindShould.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.junit.Test;
+import org.spine3.server.storage.datastore.dsnative.Kind;
 import org.spine3.type.TypeName;
 import org.spine3.type.TypeUrl;
 

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -26,10 +26,12 @@ import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.StructuredQuery;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -56,13 +58,12 @@ class TestDatastoreWrapper extends DatastoreWrapper {
      */
     private static final int MAX_CLEANUP_ATTEMPTS = 5;
 
-
     private static final Collection<String> kindsCache = new LinkedList<>();
 
     private final boolean waitForConsistency;
 
     private TestDatastoreWrapper(Datastore datastore, boolean waitForConsistency) {
-        super(datastore);
+        super(datastore, NamespaceSupplier.constant());
         this.waitForConsistency = waitForConsistency;
     }
 
@@ -119,9 +120,9 @@ class TestDatastoreWrapper extends DatastoreWrapper {
                 }
             }
 
-            final Query<Entity> query = Query.newEntityQueryBuilder()
-                                             .setKind(table)
-                                             .build();
+            final StructuredQuery<Entity> query = Query.newEntityQueryBuilder()
+                                                       .setKind(table)
+                                                       .build();
             final List<Entity> entities = read(query);
             remainingEntityCount = entities.size();
 
@@ -148,7 +149,7 @@ class TestDatastoreWrapper extends DatastoreWrapper {
 
         if (cleanupAttempts >= MAX_CLEANUP_ATTEMPTS && remainingEntityCount > 0) {
             throw new RuntimeException("Cannot cleanup the table: " + table +
-                    ". Remaining entity count is " + remainingEntityCount);
+                                               ". Remaining entity count is " + remainingEntityCount);
         }
     }
 

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/TestDatastoreWrapper.java
@@ -31,7 +31,8 @@ import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.spine3.server.storage.datastore.dsnative.NamespaceSupplier;
+import org.spine3.server.storage.datastore.dsnative.Kind;
+import org.spine3.server.storage.datastore.dsnative.TestNamespaceSuppliers;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -63,7 +64,7 @@ class TestDatastoreWrapper extends DatastoreWrapper {
     private final boolean waitForConsistency;
 
     private TestDatastoreWrapper(Datastore datastore, boolean waitForConsistency) {
-        super(datastore, NamespaceSupplier.constant());
+        super(datastore, TestNamespaceSuppliers.singleTenant());
         this.waitForConsistency = waitForConsistency;
     }
 
@@ -72,8 +73,8 @@ class TestDatastoreWrapper extends DatastoreWrapper {
     }
 
     @Override
-    public KeyFactory getKeyFactory(String kind) {
-        kindsCache.add(kind);
+    public KeyFactory getKeyFactory(Kind kind) {
+        kindsCache.add(kind.getValue());
         return super.getKeyFactory(kind);
     }
 

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/dsnative/TestNamespaceSuppliers.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/dsnative/TestNamespaceSuppliers.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.datastore.dsnative;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class TestNamespaceSuppliers {
+
+    public static NamespaceSupplier singleTenant() {
+        return NamespaceSupplier.constant();
+    }
+
+    public static NamespaceSupplier multitenant() {
+        return NamespaceSupplier.multitenant();
+    }
+}


### PR DESCRIPTION
Added support for _multitenant_ storage structure.
The feature is implemented on the base of the Datastore-native mechanism of _namespaces_.
For more info about the namespaces see [the official doc](https://cloud.google.com/datastore/docs/concepts/multitenancy).

