### PR TITLE
Fix custom namespace parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 project.ext {
     SPINE_VERSION = '0.8.34-SNAPSHOT'
-    GAE_JAVA_VERSION = "0.8.34-SNAPSHOT"
+    GAE_JAVA_VERSION = "0.8.34.1-SNAPSHOT"
     PROTOBUF_VERSION = '3.2.0'
     SLf4J_VERSION = "1.7.21"
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}"

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreStorageFactory.java
@@ -23,7 +23,6 @@ package org.spine3.server.storage.datastore;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Supplier;
 import com.google.protobuf.Message;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.aggregate.AggregateStorage;
@@ -33,7 +32,6 @@ import org.spine3.server.projection.ProjectionStorage;
 import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.StorageFactory;
-import org.spine3.server.storage.datastore.tenant.Namespace;
 import org.spine3.server.storage.datastore.tenant.NamespaceSupplier;
 import org.spine3.server.storage.datastore.tenant.NamespaceToTenantIdConverter;
 import org.spine3.server.storage.datastore.tenant.TenantConverterRegistry;
@@ -66,7 +64,7 @@ public class DatastoreStorageFactory implements StorageFactory {
     private final DatastoreWrapper datastore;
     private final boolean multitenant;
     private final ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> typeRegistry;
-    private final Supplier<Namespace> namespaceSupplier;
+    private final NamespaceSupplier namespaceSupplier;
     private final NamespaceToTenantIdConverter namespaceToTenantIdConverter;
 
     private DatastoreStorageFactory(Builder builder) {
@@ -82,7 +80,7 @@ public class DatastoreStorageFactory implements StorageFactory {
     protected DatastoreStorageFactory(Datastore datastore,
                                       boolean multitenant,
                                       ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> typeRegistry,
-                                      Supplier<Namespace> namespaceSupplier,
+                                      NamespaceSupplier namespaceSupplier,
                                       @Nullable NamespaceToTenantIdConverter namespaceConverter) {
         this.multitenant = multitenant;
         this.typeRegistry = typeRegistry;
@@ -94,7 +92,7 @@ public class DatastoreStorageFactory implements StorageFactory {
     protected DatastoreStorageFactory(DatastoreWrapper datastore,
                                       boolean multitenant,
                                       ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> typeRegistry,
-                                      Supplier<Namespace> namespaceSupplier,
+                                      NamespaceSupplier namespaceSupplier,
                                       @Nullable NamespaceToTenantIdConverter namespaceConverter) {
         this.datastore = checkNotNull(datastore);
         this.multitenant = multitenant;
@@ -134,7 +132,8 @@ public class DatastoreStorageFactory implements StorageFactory {
                ? new DatastoreStorageFactory(getDatastore(),
                                              false,
                                              typeRegistry,
-                                             NamespaceSupplier.singleTenant(), namespaceToTenantIdConverter)
+                                             NamespaceSupplier.singleTenant(),
+                                             namespaceToTenantIdConverter)
                : this;
     }
 
@@ -238,8 +237,8 @@ public class DatastoreStorageFactory implements StorageFactory {
         private Datastore datastore;
         private boolean multitenant;
         private ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> typeRegistry;
-        private Supplier<Namespace> namespaceSupplier;
-        public NamespaceToTenantIdConverter namespaceToTenantIdConverter;
+        private NamespaceSupplier namespaceSupplier;
+        private NamespaceToTenantIdConverter namespaceToTenantIdConverter;
 
         private Builder() {
             // Avoid direct initialization
@@ -329,7 +328,7 @@ public class DatastoreStorageFactory implements StorageFactory {
             return new DatastoreStorageFactory(this);
         }
 
-        private Supplier<Namespace> createNamespaceSupplier() {
+        private NamespaceSupplier createNamespaceSupplier() {
             final String defaultNamespace;
             if (multitenant) {
                 checkHasNoNamespace(datastore);
@@ -338,9 +337,9 @@ public class DatastoreStorageFactory implements StorageFactory {
                 defaultNamespace = datastore.getOptions()
                                             .getNamespace();
             }
-            final Supplier<Namespace> result = NamespaceSupplier.instance(multitenant,
-                                                                          defaultNamespace,
-                                                                          ProjectId.of(datastore));
+            final NamespaceSupplier result = NamespaceSupplier.instance(multitenant,
+                                                                        defaultNamespace,
+                                                                        ProjectId.of(datastore));
             return result;
         }
 

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/DatastoreWrapper.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.server.storage.datastore.tenant.DsNamespaceValidator;
 import org.spine3.server.storage.datastore.tenant.Namespace;
+import org.spine3.server.storage.datastore.tenant.NamespaceSupplier;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -78,7 +79,7 @@ public class DatastoreWrapper {
 
     private static final Map<Kind, KeyFactory> keyFactories = new HashMap<>();
 
-    private final Supplier<Namespace> namespaceSupplier;
+    private final NamespaceSupplier namespaceSupplier;
     private final Datastore datastore;
     private Transaction activeTransaction;
     private DatastoreReaderWriter actor;
@@ -92,7 +93,7 @@ public class DatastoreWrapper {
      * @param namespaceSupplier the instance of {@link Supplier Namespace Supplier}, providing
      *                          the namespaces for Datastore queries
      */
-    protected DatastoreWrapper(Datastore datastore, Supplier<Namespace> namespaceSupplier) {
+    protected DatastoreWrapper(Datastore datastore, NamespaceSupplier namespaceSupplier) {
         this.namespaceSupplier = checkNotNull(namespaceSupplier);
         this.datastore = checkNotNull(datastore);
         this.actor = datastore;
@@ -109,7 +110,7 @@ public class DatastoreWrapper {
      */
     @SuppressWarnings("WeakerAccess") // Part of API
     protected static DatastoreWrapper wrap(Datastore datastore,
-                                           Supplier<Namespace> namespaceSupplier) {
+                                           NamespaceSupplier namespaceSupplier) {
         return new DatastoreWrapper(datastore, namespaceSupplier);
     }
 
@@ -451,7 +452,8 @@ public class DatastoreWrapper {
 
     private DsNamespaceValidator namespaceValidator() {
         if (namespaceValidator == null) {
-            namespaceValidator = new DsNamespaceValidator(getDatastore());
+            namespaceValidator = new DsNamespaceValidator(getDatastore(),
+                                                          namespaceSupplier.isMultitenant());
         }
         return namespaceValidator;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DatastoreTenants.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DatastoreTenants.java
@@ -69,14 +69,15 @@ public final class DatastoreTenants {
      * </pre>
      *
      * <p>A single-tenant app (or a single-tenant BoundedContext in a multitenant app) does not
-     * require a {@code TenantIndex} to be set explicitly.
+     * require a {@code TenantIndex} to be set explicitly, so this method assumes that it is an a
+     * single tenant context.
      *
      * @param datastore the {@link Datastore} to get the {@link TenantIndex} for
      * @return a new instance of the {@link TenantIndex}
      */
     public static TenantIndex index(Datastore datastore) {
         checkNotNull(datastore);
-        final TenantIndex index = new NamespaceIndex(datastore);
+        final TenantIndex index = new NamespaceIndex(datastore, true);
         return index;
     }
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DatastoreTenants.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DatastoreTenants.java
@@ -77,7 +77,7 @@ public final class DatastoreTenants {
      */
     public static TenantIndex index(Datastore datastore) {
         checkNotNull(datastore);
-        // We assume a single-tenant execution environment
+        // We assume we are in a single-tenant execution environment
         final TenantIndex index = new NamespaceIndex(datastore, true);
         return index;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DatastoreTenants.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DatastoreTenants.java
@@ -77,6 +77,7 @@ public final class DatastoreTenants {
      */
     public static TenantIndex index(Datastore datastore) {
         checkNotNull(datastore);
+        // We assume a single-tenant execution environment
         final TenantIndex index = new NamespaceIndex(datastore, true);
         return index;
     }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DsNamespaceValidator.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/DsNamespaceValidator.java
@@ -41,8 +41,8 @@ public class DsNamespaceValidator {
      *
      * @param datastore the {@link Datastore} to validate the {@linkplain Namespace namespaces} upon
      */
-    public DsNamespaceValidator(Datastore datastore) {
-        this.namespaceIndex = new NamespaceIndex(datastore);
+    public DsNamespaceValidator(Datastore datastore, boolean multitenant) {
+        this.namespaceIndex = new NamespaceIndex(datastore, multitenant);
     }
 
     /**

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/MultitenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/MultitenantNamespaceSupplier.java
@@ -60,6 +60,11 @@ final class MultitenantNamespaceSupplier extends NamespaceSupplier {
         return result;
     }
 
+    @Override
+    public boolean isMultitenant() {
+        return true;
+    }
+
     /**
      * A function declosuring the current tenant {@linkplain TenantId ID}.
      *

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/Namespace.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/Namespace.java
@@ -162,7 +162,7 @@ public final class Namespace {
             tenantIdConverterType = TenantIdConverterType.SINGLE_CUSTOM;
         } else if (customConverter.isPresent()) {
             tenantIdConverterType = TenantIdConverterType.PREDEFINED_VALUE;
-        } else  {
+        } else {
             final String typePrefix = String.valueOf(namespace.charAt(0));
             tenantIdConverterType = TYPE_PREFIX_TO_CONVERTER.get(typePrefix);
             checkState(tenantIdConverterType != null,
@@ -294,6 +294,5 @@ public final class Namespace {
             this.namespaceConverter = namespaceConverter;
         }
     }
-
 
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/NamespaceSupplier.java
@@ -82,5 +82,10 @@ public abstract class NamespaceSupplier implements Supplier<Namespace> {
     @Override
     public abstract Namespace get();
 
+    /**
+     * Shown if this instance of {@code NamespaceSupplier} is multitenant or not.
+     *
+     * @return {@code true} if this supplier is multitenant, {@code false} otherwise
+     */
     public abstract boolean isMultitenant();
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/NamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/NamespaceSupplier.java
@@ -81,4 +81,6 @@ public abstract class NamespaceSupplier implements Supplier<Namespace> {
         // Overrides to provide a descriptive documentation
     @Override
     public abstract Namespace get();
+
+    public abstract boolean isMultitenant();
 }

--- a/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/SingleTenantNamespaceSupplier.java
+++ b/gcd/src/main/java/org/spine3/server/storage/datastore/tenant/SingleTenantNamespaceSupplier.java
@@ -52,6 +52,11 @@ final class SingleTenantNamespaceSupplier extends NamespaceSupplier {
         return namespace;
     }
 
+    @Override
+    public boolean isMultitenant() {
+        return false;
+    }
+
     private enum NamespaceSingleton {
         INSTANCE;
         @SuppressWarnings("NonSerializableFieldInSerializableClass")

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/DatastoreWrapperShould.java
@@ -26,7 +26,6 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import com.google.protobuf.Any;
 import org.junit.AfterClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.spine3.net.EmailAddress;
 import org.spine3.net.InternetDomain;
@@ -128,8 +127,6 @@ public class DatastoreWrapperShould {
         wrapper.dropAllTables();
     }
 
-    @Ignore
-        // https://github.com/SpineEventEngine/gae-java/issues/35
     @Test
     public void generate_key_factories_aware_of_tenancy() {
         final ProjectId projectId = ProjectId.of(TestDatastoreStorageFactory.DEFAULT_DATASET_NAME);

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/tenant/NamespaceIndexShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/tenant/NamespaceIndexShould.java
@@ -72,13 +72,13 @@ public class NamespaceIndexShould {
         new NullPointerTester()
                 .setDefault(Namespace.class, defaultNamespace)
                 .setDefault(TenantId.class, tenantId)
-                .testInstanceMethods(new NamespaceIndex(mockDatastore()),
+                .testInstanceMethods(new NamespaceIndex(mockDatastore(), true),
                                      NullPointerTester.Visibility.PACKAGE);
     }
 
     @Test
     public void store_tenant_ids() {
-        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore());
+        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore(), true);
 
         final Set<TenantId> initialEmptySet = namespaceIndex.getAll();
         assertTrue(initialEmptySet.isEmpty());
@@ -99,7 +99,7 @@ public class NamespaceIndexShould {
 
     @Test
     public void do_nothing_on_close() {
-        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore());
+        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore(), false);
 
         namespaceIndex.close();
         namespaceIndex.close();
@@ -108,7 +108,7 @@ public class NamespaceIndexShould {
 
     @Test
     public void find_existing_namespaces() {
-        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore());
+        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore(), true);
 
         // Ensure no namespace has been kept
         final Set<TenantId> initialEmptySet = namespaceIndex.getAll();
@@ -125,7 +125,7 @@ public class NamespaceIndexShould {
 
     @Test
     public void not_find_non_existing_namespaces() {
-        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore());
+        final NamespaceIndex namespaceIndex = new NamespaceIndex(mockDatastore(), true);
 
         // Ensure no namespace has been kept
         final Set<TenantId> initialEmptySet = namespaceIndex.getAll();
@@ -166,7 +166,9 @@ public class NamespaceIndexShould {
             }
         };
         // The tested object
-        final NamespaceIndex namespaceIndex = new NamespaceIndex(namespaceQuery, TEST_PROJECT_ID);
+        final NamespaceIndex namespaceIndex = new NamespaceIndex(namespaceQuery,
+                                                                 TEST_PROJECT_ID,
+                                                                 true);
 
         // The test flow
         final Runnable flow = new Runnable() {

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/tenant/NamespaceShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/tenant/NamespaceShould.java
@@ -31,6 +31,7 @@ import org.spine3.users.TenantId;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.spine3.server.storage.datastore.Given.TEST_PROJECT_ID;
 import static org.spine3.server.storage.datastore.Given.TEST_PROJECT_ID_VALUE;
@@ -128,8 +129,26 @@ public class NamespaceShould {
         final ProjectId projectId = ProjectId.of("project");
         final Key emptyKey = Key.newBuilder(projectId.getValue(), "my.type", 42)
                                 .build();
-        final Namespace namespace = Namespace.fromNameOf(emptyKey, projectId);
+        final Namespace namespace = Namespace.fromNameOf(emptyKey, false);
         assertNull(namespace);
+    }
+
+    @Test
+    public void construct_from_Key_in_single_tenant() {
+        checkConstructFromKey("my.test.single.tenant.namespace.from.key", false);
+    }
+
+    @Test
+    public void construct_from_Key_in_multitenant() {
+        checkConstructFromKey("Vmy.test.single.tenant.namespace.from.key", true);
+    }
+
+    private static void checkConstructFromKey(String ns, boolean multitenant) {
+        final Key key = Key.newBuilder("my-simple-project", "any.kind", ns)
+                           .build();
+        final Namespace namespace = Namespace.fromNameOf(key, multitenant);
+        assertNotNull(namespace);
+        assertEquals(ns, namespace.getValue());
     }
 
     @Test

--- a/gcd/src/test/java/org/spine3/server/storage/datastore/tenant/NamespaceWithCustomConverterShould.java
+++ b/gcd/src/test/java/org/spine3/server/storage/datastore/tenant/NamespaceWithCustomConverterShould.java
@@ -40,7 +40,7 @@ import static org.spine3.server.storage.datastore.tenant.TenantConverterRegistry
  */
 public class NamespaceWithCustomConverterShould {
 
-    private static final ProjectId PROJECT_ID = ProjectId.of("ARBITRARYPROJECT");
+    private static final ProjectId PROJECT_ID = ProjectId.of("arbitraryproject");
 
     @BeforeClass
     public static void setUp() {
@@ -65,9 +65,9 @@ public class NamespaceWithCustomConverterShould {
     @Test
     public void construct_from_Key() {
         final String ns = "my.test.namespace.from.key";
-        final Key key = Key.newBuilder("my-project", "some.kind", ns)
+        final Key key = Key.newBuilder(PROJECT_ID.getValue(), "some.kind", ns)
                            .build();
-        final Namespace namespace = Namespace.fromNameOf(key, PROJECT_ID);
+        final Namespace namespace = Namespace.fromNameOf(key, true);
         assertNotNull(namespace);
         assertEquals(ns, namespace.getValue());
     }


### PR DESCRIPTION
This PR provides a fix for a start-up crash.

Conditions:
 - a single-tenant execution environment;
 - a single custom namespace within the Datastore.

The scenario is now covered with tests.