### PR TITLE
Reference the proper type in the Javadoc section.

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/type/DatastoreTypeRegistryFactory.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/type/DatastoreTypeRegistryFactory.java
@@ -62,14 +62,15 @@ public final class DatastoreTypeRegistryFactory {
      * The returned registry contains the
      * {@linkplain io.spine.server.entity.storage.ColumnType column types} declarations for:
      * <ul>
-     *     <li>{@code String}
-     *     <li>{@code Integer}
-     *     <li>{@code Long}
-     *     <li>{@code Boolean}
-     *     <li>{@link Timestamp} stored as {@link com.google.cloud.datastore.DateTime DateTime}
-     *     <li>{@link AbstractMessage Message} stored as a {@code String} retrieved form a
-     *     {@link io.spine.string.Stringifier Stringifier}
-     *     <li>{@link Version} stored as an {@code int} version number
+     *     <li> {@code String}
+     *     <li> {@code Integer}
+     *     <li> {@code Long}
+     *     <li> {@code Boolean}
+     *     <li> {@link Timestamp} stored as {@link com.google.cloud.Timestamp
+     *          com.google.cloud.Timestamp}
+     *     <li> {@link AbstractMessage Message} stored as a {@code String} retrieved form a
+     *          {@link io.spine.string.Stringifier Stringifier}
+     *     <li> {@link Version} stored as an {@code int} version number
      * </ul>
      *
      * @return the default {@code ColumnTypeRegistry} for storing the Entity Columns in Datastore


### PR DESCRIPTION
This PR addresses the Javadoc issue that prevented artifact publishing. Wrong type has been referenced in the description of the type registry factory.

The library version is not changed along with the fix — as nothing has been modified except for a Javadoc portion.