### PR TITLE
Optimize reading of aggregates

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -223,8 +223,8 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
                     .setKind(stateTypeName.value())
                     .setFilter(eq(aggregate_id.toString(),
                                   idString))
-                    .setOrderBy(byCreatedTime(),
-                                byVersion(),
+                    .setOrderBy(byVersion(),
+                                byCreatedTime(),
                                 byRecordType())
                     .setLimit(limit)
                     .build();

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -181,8 +181,9 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
     /**
      * {@inheritDoc}
      *
-     * <p>The resulting iterator will fetch {@linkplain AggregateEventRecord events}
-     * by batches. Size of a batch is specified by the given {@link AggregateReadRequest}.
+     * <p>The resulting iterator will fetch {@linkplain AggregateEventRecord events} batch by batch.
+     *
+     * <p>Size of the batch is specified by the given {@link AggregateReadRequest}.
      *
      * @param request the read request
      * @return a new iterator instance

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorage.java
@@ -72,7 +72,6 @@ public class DsStandStorage extends StandStorage {
         return recordStorage.delete(id);
     }
 
-    @Nullable
     @Override
     protected Optional<EntityRecord> readRecord(AggregateStateId id) {
         final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(id);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorage.java
@@ -21,12 +21,12 @@
 package io.spine.server.storage.datastore;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.FieldMask;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
 import io.spine.server.stand.AggregateStateId;
 import io.spine.server.stand.StandStorage;
+import io.spine.server.storage.RecordReadRequest;
 import io.spine.server.storage.RecordStorage;
 import io.spine.type.TypeUrl;
 
@@ -75,7 +75,8 @@ public class DsStandStorage extends StandStorage {
     @Nullable
     @Override
     protected Optional<EntityRecord> readRecord(AggregateStateId id) {
-        return recordStorage.read(id);
+        final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(id);
+        return recordStorage.read(request);
     }
 
     @Override

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
@@ -20,8 +20,10 @@
 
 package io.spine.server.storage.datastore;
 
+import com.google.cloud.datastore.EntityQuery;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateEventRecord;
+import io.spine.server.aggregate.AggregateReadRequest;
 import io.spine.server.aggregate.AggregateStorage;
 import io.spine.server.aggregate.AggregateStorageShould;
 import io.spine.server.entity.Entity;
@@ -34,6 +36,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
@@ -96,6 +99,18 @@ public class DsAggregateStorageShould extends AggregateStorageShould {
         final DsAggregateStorage<ProjectId> storage = (DsAggregateStorage<ProjectId>) getStorage();
         storage.writeRecord(Sample.messageOfType(ProjectId.class),
                             AggregateEventRecord.getDefaultInstance());
+    }
+
+    @Test
+    public void set_limit_for_history_backward_query() {
+        final DsAggregateStorage<ProjectId> storage = (DsAggregateStorage<ProjectId>) getStorage();
+        final int batchSize = 10;
+        final AggregateReadRequest<ProjectId> request = new AggregateReadRequest<>(newId(),
+                                                                                   batchSize);
+        final EntityQuery historyBackwardQuery = storage.historyBackwardQuery(request);
+
+        final int queryLimit = historyBackwardQuery.getLimit();
+        assertEquals(batchSize, queryLimit);
     }
 
     private static Logger log() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
@@ -124,6 +124,7 @@ public class DsAggregateStorageShould extends AggregateStorageShould {
     @Test
     public void still_load_aggregates_properly_after_snapshot_trigger_decrease_at_runtime() {
         final ProjectAggregateRepository repository = new ProjectAggregateRepository();
+        repository.initStorage(datastoreFactory);
         repository.setBoundedContext(BoundedContext.newBuilder()
                                                    .build());
         final ProjectId id = newId();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
@@ -144,8 +144,8 @@ public class DsAggregateStorageShould extends AggregateStorageShould {
         repository.setSnapshotTrigger(minimalSnapshotTrigger);
         final ProjectAggregate aggregate = repository.find(id)
                                                      .get();
-        assertEquals(initialSnapshotTrigger, aggregate.getState()
-                                                      .getTaskCount());
+        assertEquals(tasksCount, aggregate.getState()
+                                          .getTaskCount());
     }
 
     private static void register(AggregateRepository repository) {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
@@ -27,11 +27,11 @@ import io.spine.server.BoundedContext;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateEventRecord;
 import io.spine.server.aggregate.AggregateReadRequest;
-import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.AggregateStorage;
 import io.spine.server.aggregate.AggregateStorageShould;
 import io.spine.server.aggregate.given.AggregateRepositoryTestEnv.ProjectAggregate;
 import io.spine.server.entity.Entity;
+import io.spine.server.storage.datastore.given.DsAggregateStorageTestEnv.ProjectAggregateRepository;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.command.AggAddTask;
 import io.spine.testdata.Sample;
@@ -147,16 +147,6 @@ public class DsAggregateStorageShould extends AggregateStorageShould {
                                                      .get();
         assertEquals(tasksCount, aggregate.getState()
                                           .getTaskCount());
-    }
-
-    private static class ProjectAggregateRepository
-            extends AggregateRepository<ProjectId, ProjectAggregate> {
-
-        @SuppressWarnings("RedundantMethodOverride") // To expose the method for testing.
-        @Override
-        protected void setSnapshotTrigger(int snapshotTrigger) {
-            super.setSnapshotTrigger(snapshotTrigger);
-        }
     }
 
     private static Logger log() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
@@ -43,6 +43,7 @@ import io.spine.server.entity.LifecycleFlags;
 import io.spine.server.entity.storage.Column;
 import io.spine.server.entity.storage.EntityQuery;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
+import io.spine.server.storage.RecordReadRequest;
 import io.spine.server.storage.RecordStorage;
 import io.spine.server.storage.RecordStorageShould;
 import io.spine.test.storage.Project;
@@ -278,7 +279,8 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId,
         final EntityRecordWithColumns recordWithColumns = create(record, entity);
         final RecordStorage<ProjectId> storage = getStorage();
         storage.write(id, recordWithColumns);
-        final Optional<EntityRecord> restoredRecordOptional = storage.read(id);
+        final RecordReadRequest<ProjectId> request = new RecordReadRequest<>(id);
+        final Optional<EntityRecord> restoredRecordOptional = storage.read(request);
         assertTrue(restoredRecordOptional.isPresent());
         final EntityRecord restoredRecord = restoredRecordOptional.get();
         // Includes Lifecycle flags comparison

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/DsAggregateStorageTestEnv.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/DsAggregateStorageTestEnv.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore.given;
+
+import io.spine.server.aggregate.AggregateRepository;
+import io.spine.server.aggregate.given.AggregateRepositoryTestEnv.ProjectAggregate;
+import io.spine.test.aggregate.ProjectId;
+
+/**
+ * @author Dmytro Grankin
+ */
+public class DsAggregateStorageTestEnv {
+
+    private DsAggregateStorageTestEnv() {
+        // Prevent instantiation of this class.
+    }
+
+    /**
+     * A repository to check loading of an aggregates by the storage for different snapshot triggers.
+     */
+    public static class ProjectAggregateRepository
+            extends AggregateRepository<ProjectId, ProjectAggregate> {
+
+        @SuppressWarnings("RedundantMethodOverride") // To expose the method for testing.
+        @Override
+        public void setSnapshotTrigger(int snapshotTrigger) {
+            super.setSnapshotTrigger(snapshotTrigger);
+        }
+    }
+}

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  This file is used wherever the library versions are required.
  */
 
-final SPINE_VERSION = "0.9.75-SNAPSHOT"
+final SPINE_VERSION = "0.9.76-SNAPSHOT"
 
 ext {
     spineVersion = SPINE_VERSION

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  This file is used wherever the library versions are required.
  */
 
-final SPINE_VERSION = "0.9.66-SNAPSHOT"
+final SPINE_VERSION = "0.9.75-SNAPSHOT"
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes #60.

Recently, `Storage.read(...)` method was reworked. See details in the [PR](https://github.com/SpineEventEngine/core-java/pull/596).

`DsAggregateStorage` was updated accordingly and now it uses a batch size from the newly introduced `AggregateReadRequest` to read a history of an aggregate by batches.

Also, ordering of events in `DsAggregateStorage` was fixed. Before, events were sorted by creation time and only then by version. But ordering by version is more important, so current storage implementation sorts events by version and only then by creation time.

Spine version was increased to `0.9.76-SNAPSHOT`.

