### PR TITLE
Fix entity column reads

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,49 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
+      <option name="JD_P_AT_EMPTY_LINES" value="false" />
+      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    </JavaCodeStyleSettings>
+    <XML>
+      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+      <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="RESOURCE_LIST_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <arrangement>
+        <groups>
+          <group>
+            <type>GETTERS_AND_SETTERS</type>
+            <order>KEEP</order>
+          </group>
+          <group>
+            <type>OVERRIDDEN_METHODS</type>
+            <order>KEEP</order>
+          </group>
+        </groups>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
     apply plugin: 'maven'
     apply plugin: 'jacoco'
     group = 'io.spine'
-    version = project.spineVersion
+    version = project.spineGaeVersion
 
     repositories {
         mavenCentral()

--- a/datastore/build.gradle
+++ b/datastore/build.gradle
@@ -1,5 +1,6 @@
 ext {
     artifactId = 'gae-java'
+    datastoreVersion = '1.12.0'
 }
 
 buildscript {
@@ -14,7 +15,7 @@ configurations.all {
 
 dependencies {
     // Google Cloud Datastore
-    compile(group: 'com.google.cloud', name: 'google-cloud-datastore', version: '1.2.1') {
+    compile(group: 'com.google.cloud', name: 'google-cloud-datastore', version: datastoreVersion) {
         exclude group: 'com.google.protobuf'
     }
 }

--- a/datastore/build.gradle
+++ b/datastore/build.gradle
@@ -1,6 +1,5 @@
 ext {
     artifactId = 'gae-java'
-    datastoreVersion = '1.12.0'
 }
 
 buildscript {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsIdentifiers.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsIdentifiers.java
@@ -25,7 +25,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import io.spine.string.Stringifiers;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Utilities for working with GAE Datastore record identifiers and keys.
@@ -57,7 +57,7 @@ public class DsIdentifiers {
     }
 
     public static RecordId of(String value) {
-        checkState(!value.isEmpty());
+        checkArgument(!value.isEmpty());
         return new RecordId(value);
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -221,7 +221,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         final QueryParameters params = entityQuery.getParameters();
         if (!idFilter.isEmpty()) { // IDs query
             final Predicate<Entity> inMemPredicate;
-            if (!params.iterator().hasNext()) { // IDs and columns query
+            if (params.iterator().hasNext()) { // IDs and columns query
                 inMemPredicate = buildMemoryPredicate(params);
             } else {
                 inMemPredicate = alwaysTrue();

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -213,37 +213,86 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         if (query.getIds().isEmpty() && !query.getParameters().iterator().hasNext()) {
             return readAll(fieldMask);
         }
-        return queryByColumns(query, fieldMask);
+        return queryBy(query, fieldMask);
     }
 
-    private Iterator<EntityRecord> queryByColumns(EntityQuery<I> entityQuery, FieldMask fieldMask) {
+    /**
+     * Performs Datastore query by the given {@link EntityQuery}.
+     *
+     * <p>This method assumes that there are either IDs of query parameters or both in the given
+     * {@code EntityQuery} (i.e. the query is not empty).
+     *
+     * @param entityQuery the {@link EntityQuery} to query the Datastore by
+     * @param fieldMask   the {@code FieldMask} to apply to all the retrieved entity states
+     * @return an iterator over the resulting entity records
+     */
+    private Iterator<EntityRecord> queryBy(EntityQuery<I> entityQuery, FieldMask fieldMask) {
         final Collection<I> idFilter = entityQuery.getIds();
         final QueryParameters params = entityQuery.getParameters();
-        if (!idFilter.isEmpty()) { // IDs query
-            final Predicate<Entity> inMemPredicate;
-            if (params.iterator().hasNext()) { // IDs and columns query
-                inMemPredicate = buildMemoryPredicate(params);
-            } else {
-                inMemPredicate = alwaysTrue();
-            }
-            final Iterator<EntityRecord> records = lookup(idFilter, fieldMask, inMemPredicate);
-            return records;
+        final Iterator<EntityRecord> result;
+        if (!idFilter.isEmpty()) {
+            result = queryByIdsAndColumns(idFilter, params, fieldMask);
+        } else {
+            result = queryByColumnsOnly(params, fieldMask);
         }
-        // Only column query
+        return result;
+    }
+
+    /**
+     * Performs a query by IDs and entity columns.
+     *
+     * <p>The by-IDs query is performed on Datastore, and the by-columns filtering is done in
+     * memory.
+     *
+     * @param acceptableIds the IDs to search by
+     * @param params        the additional query parameters
+     * @param fieldMask     the {@code FieldMask} to apply to all the retrieved entity states
+     * @return an iterator over the resulting entity records
+     */
+    private Iterator<EntityRecord> queryByIdsAndColumns(Collection<I> acceptableIds,
+                                                        QueryParameters params,
+                                                        FieldMask fieldMask) {
+        final Predicate<Entity> inMemPredicate;
+        if (params.iterator().hasNext()) { // IDs and columns query
+            inMemPredicate = buildMemoryPredicate(params);
+        } else { // Only IDs query
+            inMemPredicate = alwaysTrue();
+        }
+        final Iterator<EntityRecord> records = lookup(acceptableIds, fieldMask, inMemPredicate);
+        return records;
+    }
+
+    /**
+     * Performs a query by entity columns.
+     *
+     * <p>The query is performed on Datastore. A single call to this method may turn into a few API
+     * calls. See {@link DsFilters} for details.
+     *
+     * @param params    the by-column query parameters
+     * @param fieldMask the {@code FieldMask} to apply to all the retrieved entity states
+     * @return an iterator over the resulting entity records
+     */
+    private Iterator<EntityRecord> queryByColumnsOnly(QueryParameters params,
+                                                      FieldMask fieldMask) {
         final StructuredQuery.Builder<Entity> datastoreQuery = Query.newEntityQueryBuilder()
                                                                     .setKind(getKind().getValue());
         final Collection<Filter> filters = buildColumnFilters(params);
-        final Collection<StructuredQuery<Entity>> queries = transform(
-                filters,
-                new Function<Filter, StructuredQuery<Entity>>() {
-                    @Override
-                    public StructuredQuery<Entity> apply(@Nullable Filter input) {
-                        checkNotNull(input);
-                        return datastoreQuery.setFilter(input)
-                                             .build();
-                    }
-                }
-        );
+        final FilterToQuery function = new FilterToQuery(datastoreQuery);
+        final Collection<StructuredQuery<Entity>> queries = transform(filters, function);
+        final Iterator<EntityRecord> result = queryAndMerge(queries, fieldMask);
+        return result;
+    }
+
+    /**
+     * Performs the given Datastore {@linkplain StructuredQuery queries} and combines results into
+     * a single lazy iterator.
+     *
+     * @param queries   the queries to perform
+     * @param fieldMask the {@code FieldMask} to apply to all the retrieved entity states
+     * @return an iterator over the resulting entity records
+     */
+    private Iterator<EntityRecord> queryAndMerge(Iterable<StructuredQuery<Entity>> queries,
+                                                 FieldMask fieldMask) {
         Iterator<EntityRecord> result = emptyIterator();
         for (StructuredQuery<Entity> query : queries) {
             final Iterator<EntityRecord> records = queryAll(typeUrl,
@@ -535,6 +584,23 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
 
             final boolean result = eval(actual, filter.getOperator(), expected);
             return result;
+        }
+    }
+
+    private static class FilterToQuery implements Function<Filter, StructuredQuery<Entity>> {
+
+        private final StructuredQuery.Builder<Entity> builder;
+
+        private FilterToQuery(StructuredQuery.Builder<Entity> builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public StructuredQuery<Entity> apply(@Nullable Filter filter) {
+            checkNotNull(filter);
+            final StructuredQuery<Entity> query = builder.setFilter(filter)
+                                                         .build();
+            return query;
         }
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -587,6 +587,10 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         }
     }
 
+    /**
+     * A function transforming the input {@link Filter} into a {@link StructuredQuery} with
+     * the given builder.
+     */
     private static class FilterToQuery implements Function<Filter, StructuredQuery<Entity>> {
 
         private final StructuredQuery.Builder<Entity> builder;

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -288,10 +288,10 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
      * a single lazy iterator.
      *
      * <p>The resulting iterator is constructed of
-     * {@linkplain DatastoreWrapper#read(StructuredQuery) Datastore query iterators} concatenated
-     * together one by one. The Each of them is evaluated only after the previous one runs out of
-     * records (i.e. {@code hasNext()} method returns {@code false}). The order of the iterators
-     * corresponds to the order of the {@code queries}.
+     * {@linkplain DatastoreWrapper#read(StructuredQuery) Datastore query response iterators}
+     * concatenated together one by one. Each of them is evaluated only after the previous one runs
+     * out of records (i.e. {@code hasNext()} method returns {@code false}). The order of
+     * the iterators corresponds to the order of the {@code queries}.
      *
      * @param queries   the queries to perform
      * @param fieldMask the {@code FieldMask} to apply to all the retrieved entity states

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -31,6 +31,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -245,7 +246,10 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         );
         Iterator<EntityRecord> result = emptyIterator();
         for (StructuredQuery<Entity> query : queries) {
-            final Iterator<EntityRecord> records = queryAll(typeUrl, query, fieldMask);
+            final Iterator<EntityRecord> records = queryAll(typeUrl,
+                                                            query,
+                                                            fieldMask,
+                                                            Predicates.<Entity>alwaysTrue());
             result = concat(result, records);
         }
         return result;

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -265,8 +265,8 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     /**
      * Performs a query by entity columns.
      *
-     * <p>The query is performed on Datastore. A single call to this method may turn into a few API
-     * calls. See {@link DsFilters} for details.
+     * <p>The query is performed on Datastore. A single call to this method may turn into several
+     * API calls. See {@link DsFilters} for details.
      *
      * @param params    the by-column query parameters
      * @param fieldMask the {@code FieldMask} to apply to all the retrieved entity states
@@ -286,6 +286,12 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     /**
      * Performs the given Datastore {@linkplain StructuredQuery queries} and combines results into
      * a single lazy iterator.
+     *
+     * <p>The resulting iterator is constructed of
+     * {@linkplain DatastoreWrapper#read(StructuredQuery) Datastore query iterators} concatenated
+     * together one by one. The Each of them is evaluated only after the previous one runs out of
+     * records (i.e. {@code hasNext()} method returns {@code false}). The order of the iterators
+     * corresponds to the order of the {@code queries}.
      *
      * @param queries   the queries to perform
      * @param fieldMask the {@code FieldMask} to apply to all the retrieved entity states

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreIdentifiersShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreIdentifiersShould.java
@@ -38,7 +38,7 @@ public class DatastoreIdentifiersShould {
         assertHasPrivateParameterlessCtor(DsIdentifiers.class);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void not_accept_empty_String_as_identifier_source() {
         DsIdentifiers.of("");
     }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageShould.java
@@ -78,12 +78,15 @@ public class DsAggregateStorageShould extends AggregateStorageShould {
     }
 
     @Override
-    protected AggregateStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
-        return getStorage();
+    protected AggregateStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
+        @SuppressWarnings("unchecked") // Logically checked; OK for test purposes.
+        final Class<? extends Aggregate<ProjectId, ?, ?>> aggCls =
+                (Class<? extends Aggregate<ProjectId, ?, ?>>) cls;
+        return datastoreFactory.createAggregateStorage(aggCls);
     }
 
     @Override
-    protected <I> AggregateStorage<I> getStorage(Class<? extends I> idClass,
+    protected <I> AggregateStorage<I> newStorage(Class<? extends I> idClass,
                                                  Class<? extends Aggregate<I, ?, ?>> aggregateClass) {
         return datastoreFactory.createAggregateStorage(aggregateClass);
     }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsProjectionStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsProjectionStorageShould.java
@@ -67,7 +67,7 @@ public class DsProjectionStorageShould extends ProjectionStorageShould {
 
     @SuppressWarnings("unchecked") // Required for test purposes.
     @Override
-    protected ProjectionStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
+    protected ProjectionStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
         final Class<? extends Projection<ProjectId, ?, ?>> projectionClass =
                 (Class<? extends Projection<ProjectId, ?, ?>>) cls;
         final ProjectionStorage<ProjectId> result =
@@ -78,7 +78,7 @@ public class DsProjectionStorageShould extends ProjectionStorageShould {
     @Test
     public void provide_access_to_PropertyStorage_for_extensibility() {
         final DsProjectionStorage<ProjectId> storage =
-                (DsProjectionStorage<ProjectId>) getStorage(TestProjection.class);
+                (DsProjectionStorage<ProjectId>) newStorage(TestProjection.class);
         final DsPropertyStorage propertyStorage = storage.propertyStorage();
         assertNotNull(propertyStorage);
     }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
@@ -92,7 +92,7 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId,
 
     @SuppressWarnings("unchecked") // OK for tests.
     @Override
-    protected DsRecordStorage<ProjectId> getStorage(Class<? extends Entity> entityClass) {
+    protected DsRecordStorage<ProjectId> newStorage(Class<? extends Entity> entityClass) {
         final Class<? extends Entity<ProjectId, ?>> cls =
                 (Class<? extends Entity<ProjectId, ?>>) entityClass;
         return (DsRecordStorage<ProjectId>) datastoreFactory.createRecordStorage(cls);
@@ -289,7 +289,7 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId,
 
     @Test
     public void convert_entity_record_to_entity_using_column_name_for_storing() {
-        final DsRecordStorage<ProjectId> storage = getStorage(EntityWithCustomColumnName.class);
+        final DsRecordStorage<ProjectId> storage = newStorage(EntityWithCustomColumnName.class);
         final ProjectId id = newId();
         final EntityRecord record = EntityRecord.newBuilder()
                                                 .setState(pack(newState(id)))

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsStandStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsStandStorageShould.java
@@ -39,24 +39,24 @@ public class DsStandStorageShould extends StandStorageShould {
             = TestDatastoreStorageFactory.getDefaultInstance();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         datastoreFactory.setUp();
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         datastoreFactory.tearDown();
     }
 
     @Test
     public void contain_record_storage() {
         final RecordStorage<?> recordStorage =
-                ((DsStandStorage) getStorage(StandStorageRecord.class)).getRecordStorage();
+                ((DsStandStorage) newStorage(StandStorageRecord.class)).getRecordStorage();
         assertNotNull(recordStorage);
     }
 
     @Override
-    protected StandStorage getStorage(Class<? extends Entity> cls) {
+    protected StandStorage newStorage(Class<? extends Entity> aClass) {
         return datastoreFactory.createStandStorage();
     }
 }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsStandStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsStandStorageShould.java
@@ -56,7 +56,7 @@ public class DsStandStorageShould extends StandStorageShould {
     }
 
     @Override
-    protected StandStorage newStorage(Class<? extends Entity> aClass) {
+    protected StandStorage newStorage(Class<? extends Entity> cls) {
         return datastoreFactory.createStandStorage();
     }
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -18,10 +18,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ *  The versions of the libraries used.
+ *
+ *  This file is used wherever the library versions are required.
+ */
+
 ext {
     spineGaeVersion = '0.9.77-SNAPSHOT'
     spineVersion = '0.10.11-SNAPSHOT'
-
 
     // NOTE: when updating Protobuf dependency, please check that
     // Spine core modules have the same version as well.

--- a/ext.gradle
+++ b/ext.gradle
@@ -35,4 +35,6 @@ ext {
     guavaVersion = '20.0'
 
     protobufGradlePluginVerison = '0.8.3'
+
+    datastoreVersion = '1.12.0'
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -18,23 +18,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-/**
- *  The versions of the libraries used.
- *
- *  This file is used wherever the library versions are required.
- */
-
-final SPINE_VERSION = "0.9.76-SNAPSHOT"
-
 ext {
-    spineVersion = SPINE_VERSION
+    spineGaeVersion = '0.9.77-SNAPSHOT'
+    spineVersion = '0.10.11-SNAPSHOT'
+
 
     // NOTE: when updating Protobuf dependency, please check that
     // Spine core modules have the same version as well.
-    protobufVersion = '3.3.0'
+    protobufVersion = '3.5.0'
     slf4jVersion = '1.7.21'
     guavaVersion = '20.0'
 
-    protobufGradlePluginVerison = '0.8.1'
+    protobufGradlePluginVerison = '0.8.3'
 }


### PR DESCRIPTION
This PR fixes two bugs found in the entity column querying mechanism:
 - No additional in-memory predicate is applied to the filtered by columns query results now.
 - If both IDs and columns are specified, an in-memory predicate is applied to the by-IDs query results.

Also, the version of Spine has been increased up to `0.10.11-SNAPSHOT`.