### PR TITLE
Release `0.10.0`.

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  */
 
 ext {
-    spineGaeVersion = '0.9.77-SNAPSHOT'
+    spineGaeVersion = '0.10.0'
     spineVersion = '0.10.11-SNAPSHOT'
 
     // NOTE: when updating Protobuf dependency, please check that


### PR DESCRIPTION
In this PR we release the `gae-java` library of version `0.10.0`.