### PR TITLE
Extract entity columns cache to per-Storage class

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreStorageFactory.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreStorageFactory.java
@@ -162,6 +162,7 @@ public class DatastoreStorageFactory implements StorageFactory {
                                            .setDatastore(getDatastore())
                                            .setMultitenant(isMultitenant())
                                            .setIdClass(idClass)
+                                           .setEntityClass(projectionClass)
                                            .setStateType(stateType)
                                            .setColumnTypeRegistry(typeRegistry)
                                            .build();
@@ -188,6 +189,7 @@ public class DatastoreStorageFactory implements StorageFactory {
                                                          .setMultitenant(isMultitenant())
                                                          .setColumnTypeRegistry(typeRegistry)
                                                          .setIdClass(idClass)
+                                                         .setEntityClass(entityClass)
                                                          .build();
         return result;
     }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsProjectionStorageDelegate.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsProjectionStorageDelegate.java
@@ -45,8 +45,9 @@ public class DsProjectionStorageDelegate<I> extends DsRecordStorage<I> {
                                           DatastoreWrapper datastore,
                                           boolean multitenant,
                                           ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> columnTypeRegistry,
-                                          Class<I> idClass) {
-        super(descriptor, datastore, multitenant, columnTypeRegistry, idClass);
+                                          Class<I> idClass,
+                                          Class<? extends io.spine.server.entity.Entity> entityClass) {
+        super(descriptor, datastore, multitenant, columnTypeRegistry, idClass, entityClass);
     }
 
     private DsProjectionStorageDelegate(Builder<I> builder) {
@@ -54,7 +55,8 @@ public class DsProjectionStorageDelegate<I> extends DsRecordStorage<I> {
              builder.getDatastore(),
              builder.isMultitenant(),
              builder.getColumnTypeRegistry(),
-             builder.getIdClass());
+             builder.getIdClass(),
+             builder.getEntityClass());
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsRecordStorage.java
@@ -119,8 +119,9 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
     protected DsRecordStorage(Descriptor descriptor, DatastoreWrapper datastore,
                               boolean multitenant,
                               ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> columnTypeRegistry,
-                              Class<I> idClass) {
-        super(multitenant);
+                              Class<I> idClass,
+                              Class<? extends io.spine.server.entity.Entity> entityClass) {
+        super(multitenant, entityClass);
         this.typeUrl = TypeUrl.from(descriptor);
         this.datastore = datastore;
         this.columnTypeRegistry = checkNotNull(columnTypeRegistry);
@@ -133,7 +134,8 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
              builder.getDatastore(),
              builder.isMultitenant(),
              builder.getColumnTypeRegistry(),
-             builder.getIdClass());
+             builder.getIdClass(),
+             builder.getEntityClass());
     }
 
     @Override
@@ -668,6 +670,7 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         private boolean multitenant;
         private ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> columnTypeRegistry;
         private Class<I> idClass;
+        private Class<? extends io.spine.server.entity.Entity> entityClass;
 
         /**
          * Prevents direct instantiation.
@@ -724,6 +727,14 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
         }
 
         /**
+         * @param entityClass the class of the stored entity
+         */
+        public B setEntityClass(Class<? extends io.spine.server.entity.Entity> entityClass) {
+            this.entityClass = checkNotNull(entityClass);
+            return self();
+        }
+
+        /**
          * @return the {@link Descriptor} of the stored entity state type
          */
         public Descriptor getDescriptor() {
@@ -758,6 +769,13 @@ public class DsRecordStorage<I> extends RecordStorage<I> {
          */
         public Class<I> getIdClass() {
             return idClass;
+        }
+
+        /**
+         * @return the class of the stored entity
+         */
+        public Class<? extends io.spine.server.entity.Entity> getEntityClass() {
+            return entityClass;
         }
 
         final void checkRequiredFields() {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorage.java
@@ -52,61 +52,66 @@ public class DsStandStorage extends StandStorage {
 
     @Override
     public Iterator<EntityRecord> readAllByType(TypeUrl type) {
-        final Iterator<EntityRecord> records = recordStorage.readAllByType(type);
+        final Iterator<EntityRecord> records = recordStorage().readAllByType(type);
         return records;
     }
 
     @Override
     public Iterator<EntityRecord> readAllByType(TypeUrl type, FieldMask fieldMask) {
-        final Iterator<EntityRecord> records = recordStorage.readAllByType(type, fieldMask);
+        final Iterator<EntityRecord> records = recordStorage().readAllByType(type, fieldMask);
         return records;
     }
 
     @Override
     public Iterator<AggregateStateId> index() {
-        return recordStorage.index();
+        return recordStorage().index();
     }
 
     @Override
     public boolean delete(AggregateStateId id) {
-        return recordStorage.delete(id);
+        return recordStorage().delete(id);
     }
 
     @Override
     protected Optional<EntityRecord> readRecord(AggregateStateId id) {
         final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(id);
-        return recordStorage.read(request);
+        return recordStorage().read(request);
     }
 
     @Override
     protected Iterator<EntityRecord> readMultipleRecords(Iterable<AggregateStateId> ids) {
-        return recordStorage.readMultiple(ids);
+        return recordStorage().readMultiple(ids);
     }
 
     @Override
     protected Iterator<EntityRecord> readMultipleRecords(Iterable<AggregateStateId> ids,
                                                          FieldMask fieldMask) {
-        return recordStorage.readMultiple(ids, fieldMask);
+        return recordStorage().readMultiple(ids, fieldMask);
     }
 
     @Override
     protected Iterator<EntityRecord> readAllRecords() {
-        return recordStorage.readAll();
+        return recordStorage().readAll();
     }
 
     @Override
     protected Iterator<EntityRecord> readAllRecords(FieldMask fieldMask) {
-        return recordStorage.readAll(fieldMask);
+        return recordStorage().readAll(fieldMask);
     }
 
     @Override
     protected void writeRecord(AggregateStateId id, EntityRecordWithColumns record) {
-        recordStorage.write(id, record);
+        recordStorage().write(id, record);
     }
 
     @Override
     protected void writeRecords(Map<AggregateStateId, EntityRecordWithColumns> records) {
-        recordStorage.writeRecords(records);
+        recordStorage().writeRecords(records);
+    }
+
+    @Override
+    protected DsStandStorageDelegate recordStorage() {
+        return recordStorage;
     }
 
     @SuppressWarnings("unused") // Part of API

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorageDelegate.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsStandStorageDelegate.java
@@ -29,6 +29,7 @@ import com.google.cloud.datastore.StructuredQuery.Filter;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.google.protobuf.FieldMask;
+import io.spine.server.entity.AbstractVersionableEntity;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.storage.ColumnTypeRegistry;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
@@ -66,7 +67,8 @@ class DsStandStorageDelegate extends DsRecordStorage<AggregateStateId> {
               multitenant,
               ColumnTypeRegistry.<DatastoreColumnType<?, ?>>newBuilder()
                                 .build(),
-              AggregateStateId.class);
+              AggregateStateId.class,
+              AbstractVersionableEntity.class);
     }
 
     @SuppressWarnings("MethodDoesntCallSuperMethod") // Overrides a pure method behavior

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
@@ -343,8 +343,7 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId,
                                                          .setIdFilter(idFilter)
                                                          .addFilter(columnFilter)
                                                          .build();
-        final EntityQuery<ProjectId> entityQuery =
-                from(entityFilters, storage.getEntityColumnCache());
+        final EntityQuery<ProjectId> entityQuery = from(entityFilters, storage.getEntityColumnCache());
         final Iterator<EntityRecord> readResult = storage.readAll(entityQuery,
                                                                   FieldMask.getDefaultInstance());
         final List<EntityRecord> resultList = newArrayList(readResult);

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageShould.java
@@ -343,8 +343,8 @@ public class DsRecordStorageShould extends RecordStorageShould<ProjectId,
                                                          .setIdFilter(idFilter)
                                                          .addFilter(columnFilter)
                                                          .build();
-        final EntityQuery<ProjectId> entityQuery = from(entityFilters,
-                                                        storage.getEntityColumnCache());
+        final EntityQuery<ProjectId> entityQuery =
+                from(entityFilters, storage.getEntityColumnCache());
         final Iterator<EntityRecord> readResult = storage.readAll(entityQuery,
                                                                   FieldMask.getDefaultInstance());
         final List<EntityRecord> resultList = newArrayList(readResult);

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,8 +25,8 @@
  */
 
 ext {
-    spineGaeVersion = '0.10.31-SNAPSHOT'
-    spineVersion = '0.10.31-SNAPSHOT'
+    spineGaeVersion = '0.10.32-SNAPSHOT'
+    spineVersion = '0.10.32-SNAPSHOT'
 
     slf4jVersion = '1.7.21'
     jUnitVersion = '4.12'

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,8 +25,8 @@
  */
 
 ext {
-    spineGaeVersion = '0.10.32-SNAPSHOT'
-    spineVersion = '0.10.32-SNAPSHOT'
+    spineGaeVersion = '0.10.33-SNAPSHOT'
+    spineVersion = '0.10.33-SNAPSHOT'
 
     slf4jVersion = '1.7.21'
     jUnitVersion = '4.12'


### PR DESCRIPTION
This PR is a part of https://github.com/SpineEventEngine/core-java/pull/681.

It adds `EntityColumnCache` support to the `DsRecordStorage` as well as its containers such as `DsProjectionStorage` and `DsStandStorage`, and also its descendants. The PR also fixes all the code that was broken due to the changes in https://github.com/SpineEventEngine/core-java/pull/681.

`Core-java` dependency version and own library version are bumped to `0.10.32-SNAPSHOT`.

This PR should be able to build once the https://github.com/SpineEventEngine/core-java/pull/681 gets merged into the `master` branch of that repository.