### PR TITLE
Expose Datastore client lib as an API

### DIFF
--- a/datastore/build.gradle
+++ b/datastore/build.gradle
@@ -24,7 +24,7 @@ ext {
 
 dependencies {
     // Google Cloud Datastore
-    implementation(group: 'com.google.cloud', name: 'google-cloud-datastore', version: datastoreVersion) {
+    api(group: 'com.google.cloud', name: 'google-cloud-datastore', version: datastoreVersion) {
         exclude group: 'com.google.protobuf'
         exclude group: 'com.google.guava'
     }


### PR DESCRIPTION
This library depends on the Google Datastore client lib.

The API of the library expects the user to be able to use the Datastore lib as well. Thus, we make the Datastore client lib part of the API of this library by exposing it as a transitive dependency.