### PR TITLE
Fix duplicate results on query with `EITHER` filters

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsLookupByIds.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsLookupByIds.java
@@ -48,8 +48,9 @@ import static java.util.stream.Collectors.toList;
 /**
  * An {@code Entity} lookup in Google Datastore using {@code Entity} identifiers.
  *
- * @implNote Lookup is performed by reading all the entities with Datastore Keys matching
- *         the provided IDs first and then applying other query constraints in-memory.
+ * @implNote
+ * Lookup is performed by reading all the entities with Datastore Keys matching
+ * the provided IDs first and then applying other query constraints in-memory.
  */
 final class DsLookupByIds<I> {
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsLookupByQueries.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsLookupByQueries.java
@@ -47,9 +47,9 @@ import static java.util.stream.Collectors.toList;
 /**
  * An {@code Entity} lookup using {@linkplain QueryParameters Spine query parameters}.
  *
- * @implNote A single {@linkplain #find(QueryParameters, FieldMask) find()} call may turn
- *         into several Datastore reads.
- *         See {@link DsFilters} for details.
+ * @implNote
+ * A single {@linkplain #find(QueryParameters, FieldMask) find()} call may turn into several
+ * Datastore reads. See {@link DsFilters} for details.
  */
 final class DsLookupByQueries {
 
@@ -160,10 +160,18 @@ final class DsLookupByQueries {
         return recordIterator;
     }
 
+    /**
+     * Runs multiple Datastore queries in series.
+     *
+     * <p>In case of overlapping results, only one instance of {@code Entity} is taken
+     * (i.e. no duplications).
+     */
     private Stream<Entity> read(Collection<StructuredQuery<Entity>> queries) {
-        Stream<Entity> entities = queries.stream()
-                                         .map(datastore::read)
-                                         .flatMap(Streams::stream);
+        Stream<Entity> entities = queries
+                .stream()
+                .map(datastore::read)
+                .flatMap(Streams::stream)
+                .distinct();
         return entities;
     }
 }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -1064,7 +1064,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             EntityRecord record = foundEntities.get(0);
             assertEquals(entity.getState(), unpack(record.getState()));
 
-            // Check there were actually 2 Datastore reads.
+            // Check there was a correct amount of Datastore reads.
             assertDsReadByStructuredQuery(3);
         }
 

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -1041,8 +1041,10 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             CollegeEntity entity = createAndStoreEntity(storage);
 
             // Create `EITHER` column filter.
+            int randomStudentCount = 15;
             CompositeFilter eitherFilter = either(
                     eq(NAME.columnName(), entity.getName()),
+                    eq(STUDENT_COUNT.columnName(), randomStudentCount),
                     eq(PASSING_GRADE.columnName(), entity.getPassingGrade())
             );
             TargetFilters entityFilters = newTargetFilters(emptyIdFilter(), eitherFilter);
@@ -1063,7 +1065,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             assertEquals(entity.getState(), unpack(record.getState()));
 
             // Check there were actually 2 Datastore reads.
-            assertDsReadByStructuredQuery(2);
+            assertDsReadByStructuredQuery(3);
         }
 
         private void assertDsReadByStructuredQuery() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -1062,7 +1062,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             EntityRecord record = foundEntities.get(0);
             assertEquals(entity.getState(), unpack(record.getState()));
 
-            assertDsReadByStructuredQuery();
+            assertDsReadByStructuredQuery(2);
         }
 
         private void assertDsReadByStructuredQuery() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -1054,14 +1054,15 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             // Execute Query.
             Iterator<EntityRecord> readResult = storage.readAll(entityQuery, emptyFieldMask());
 
-            // Check the query results.
+            // Check the entity is "found" only once.
             List<EntityRecord> foundEntities = newArrayList(readResult);
             assertEquals(1, foundEntities.size());
 
-            // Check the record state.
+            // Check it's the target entity.
             EntityRecord record = foundEntities.get(0);
             assertEquals(entity.getState(), unpack(record.getState()));
 
+            // Check there were actually 2 Datastore reads.
             assertDsReadByStructuredQuery(2);
         }
 

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/DsRecordStorageTestEnv.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/DsRecordStorageTestEnv.java
@@ -258,7 +258,8 @@ public class DsRecordStorageTestEnv {
 
     @CanIgnoreReturnValue
     private static CollegeEntity createAndStoreEntity(RecordStorage<CollegeId> storage,
-                                                      String name, int studentCount,
+                                                      String name,
+                                                      int studentCount,
                                                       boolean stateSponsored) {
         CollegeId id = newCollegeId();
         College state = newCollege(id, name, studentCount, stateSponsored);

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/DsRecordStorageTestEnv.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/DsRecordStorageTestEnv.java
@@ -249,20 +249,20 @@ public class DsRecordStorageTestEnv {
     }
 
     @CanIgnoreReturnValue
+    public static CollegeEntity createAndStoreEntity(RecordStorage<CollegeId> storage) {
+        CollegeId id = newCollegeId();
+        CollegeEntity entity = CollegeEntity.create(id, newCollege(id));
+        storeEntity(storage, entity);
+        return entity;
+    }
+
+    @CanIgnoreReturnValue
     private static CollegeEntity createAndStoreEntity(RecordStorage<CollegeId> storage,
                                                       String name, int studentCount,
                                                       boolean stateSponsored) {
         CollegeId id = newCollegeId();
         College state = newCollege(id, name, studentCount, stateSponsored);
         CollegeEntity entity = CollegeEntity.create(id, state);
-        storeEntity(storage, entity);
-        return entity;
-    }
-
-    @CanIgnoreReturnValue
-    private static CollegeEntity createAndStoreEntity(RecordStorage<CollegeId> storage) {
-        CollegeId id = newCollegeId();
-        CollegeEntity entity = CollegeEntity.create(id, newCollege(id));
         storeEntity(storage, entity);
         return entity;
     }


### PR DESCRIPTION
This PR fixes https://github.com/SpineEventEngine/core-java/issues/649.

Google Cloud Datastore does not support `OR` composite filters so we emulate them by running multiple queries and concatenating the results.

When the query is ambigous i.e. multiple filters from `either` condition could be matched, we would return the same `Entity` more than once (one instance per match).

Now, the results produced by the Datastore lookup will be `distinct`. There is not much fancier we can do considering multiple Datastore Query [limitations](https://cloud.google.com/datastore/docs/concepts/queries#restrictions_on_queries).