### PR TITLE
Add the ability to drop excessive aggregate event records

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   global:

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreStorageFactory.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreStorageFactory.java
@@ -95,8 +95,8 @@ public class DatastoreStorageFactory implements StorageFactory {
      *         with the specified parameters
      */
     public BoundedContextBuilder newBoundedContextBuilder() {
-        Datastore datastore = getDatastore()
-                .getDatastoreOptions()
+        Datastore datastore = datastore()
+                .datastoreOptions()
                 .getService();
         TenantIndex tenantIndex = DatastoreTenants.index(datastore);
         Supplier<StorageFactory> storageFactorySupplier = () -> this;
@@ -110,7 +110,7 @@ public class DatastoreStorageFactory implements StorageFactory {
 
     private Builder toBuilder() {
         Builder result = newBuilder()
-                .setDatastore(datastore.getDatastore())
+                .setDatastore(datastore.datastore())
                 .setMultitenant(multitenant);
         if (!multitenant) {
             result.setNamespaceConverter(namespaceConverter);
@@ -156,7 +156,7 @@ public class DatastoreStorageFactory implements StorageFactory {
     private <I, B extends RecordStorageBuilder<I, B>>
     B configure(B builder, Class<? extends Entity<I, ?>> cls) {
         builder.setModelClass(asEntityClass(cls))
-               .setDatastore(getDatastore())
+               .setDatastore(datastore())
                .setMultitenant(isMultitenant())
                .setColumnTypeRegistry(typeRegistry);
         return builder;
@@ -167,7 +167,7 @@ public class DatastoreStorageFactory implements StorageFactory {
         checkNotNull(cls);
         DsPropertyStorage propertyStorage = createPropertyStorage();
         DsAggregateStorage<I> result =
-                new DsAggregateStorage<>(cls, getDatastore(), propertyStorage, multitenant);
+                new DsAggregateStorage<>(cls, datastore(), propertyStorage, multitenant);
         return result;
     }
 
@@ -185,7 +185,7 @@ public class DatastoreStorageFactory implements StorageFactory {
     }
 
     protected DsPropertyStorage createPropertyStorage() {
-        DsPropertyStorage propertyStorage = DsPropertyStorage.newInstance(getDatastore());
+        DsPropertyStorage propertyStorage = DsPropertyStorage.newInstance(datastore());
         return propertyStorage;
     }
 
@@ -201,7 +201,7 @@ public class DatastoreStorageFactory implements StorageFactory {
      * Obtains an instance of a wrapper of the passed {@link Datastore}.
      */
     @Internal
-    public DatastoreWrapper getDatastore() {
+    public DatastoreWrapper datastore() {
         return datastore;
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -388,7 +388,7 @@ public class DatastoreWrapper implements Logging {
         deleteEntities(entities);
     }
 
-    void deleteEntities(List<Entity> entities) {
+    void deleteEntities(Collection<Entity> entities) {
         List<Key> keyList =
                 entities.stream()
                         .map(BaseEntity::getKey)

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -73,7 +73,7 @@ public class DatastoreWrapper implements Logging {
             "Transaction should NOT be active.";
 
     private static final int MAX_KEYS_PER_READ_REQUEST = 1000;
-    private static final int MAX_ENTITIES_PER_WRITE_REQUEST = 500;
+    static final int MAX_ENTITIES_PER_WRITE_REQUEST = 500;
 
     private static final Map<Kind, KeyFactory> keyFactories = new HashMap<>();
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -117,7 +117,7 @@ public class DatastoreWrapper implements Logging {
      * @return the Datastore {@code Key} instance
      */
     Key keyFor(Kind kind, RecordId recordId) {
-        KeyFactory keyFactory = getKeyFactory(kind);
+        KeyFactory keyFactory = keyFactory(kind);
         Key key = keyFactory.newKey(recordId.getValue());
 
         return key;
@@ -492,7 +492,7 @@ public class DatastoreWrapper implements Logging {
      *         kind of {@link Entity} to generate keys for
      * @return an instance of {@link KeyFactory} for given kind
      */
-    public KeyFactory getKeyFactory(Kind kind) {
+    public KeyFactory keyFactory(Kind kind) {
         KeyFactory keyFactory = keyFactories.get(kind);
         if (keyFactory == null) {
             keyFactory = initKeyFactory(kind);
@@ -503,7 +503,7 @@ public class DatastoreWrapper implements Logging {
         return keyFactory;
     }
 
-    public DatastoreOptions getDatastoreOptions() {
+    public DatastoreOptions datastoreOptions() {
         DatastoreOptions options =
                 datastore.getOptions()
                          .toBuilder()
@@ -511,7 +511,7 @@ public class DatastoreWrapper implements Logging {
         return options;
     }
 
-    Datastore getDatastore() {
+    Datastore datastore() {
         return datastore;
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -219,7 +219,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
      * specified predicate.
      */
     private void truncate(int snapshotIndex, Predicate<Entity> predicate) {
-        Collection<Entity> records = EntityRecords.of(readAll())
+        Collection<Entity> records = EntityRecords.of(readAllForTenant())
                                                   .beforeSnapshot(snapshotIndex, predicate);
         datastore.deleteEntities(records);
     }
@@ -355,9 +355,9 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
         return index;
     }
 
-    private Iterator<Entity> readAll() {
+    private Iterator<Entity> readAllForTenant() {
         EntityQuery query = historyBackwardQuery().build();
-        Iterator<Entity> result = datastore.readAll(query);
+        Iterator<Entity> result = datastore.read(query);
         return result;
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -231,7 +231,6 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
     private Collection<Entity>
     recordsBeforeSnapshot(int snapshotNumber, Predicate<Entity> predicate) {
         Iterator<Entity> records = readAll();
-
         List<Entity> result = newLinkedList();
         Map<String, Integer> snapshotsHitByAggregateId = newHashMap();
         while (records.hasNext()) {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -237,18 +237,18 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
                                                                 int snapshotNumber,
                                                                 Predicate<Entity> predicate) {
         List<Entity> result = newLinkedList();
-        Map<String, Integer> snapshotsHit = newHashMap();
+        Map<String, Integer> snapshotsHitByAggregateId = newHashMap();
         while (records.hasNext()) {
             Entity record = records.next();
             String id = record.getString(aggregate_id.toString());
-            int snapshotsHitForId = snapshotsHit.get(id) != null
-                                    ? snapshotsHit.get(id)
+            int snapshotsHitForId = snapshotsHitByAggregateId.get(id) != null
+                                    ? snapshotsHitByAggregateId.get(id)
                                     : 0;
             if (snapshotsHitForId >= snapshotNumber && predicate.test(record)) {
                 result.add(record);
             }
             if (isSnapshot(record)) {
-                snapshotsHit.put(id, snapshotsHitForId + 1);
+                snapshotsHitByAggregateId.put(id, snapshotsHitForId + 1);
             }
         }
         return result;

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -314,7 +314,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
      *
      * @return the wrapped instance of Datastore
      */
-    protected DatastoreWrapper getDatastore() {
+    protected DatastoreWrapper datastore() {
         return datastore;
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsProperties.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsProperties.java
@@ -35,7 +35,7 @@ import static io.spine.server.storage.LifecycleFlagField.archived;
 import static io.spine.server.storage.LifecycleFlagField.deleted;
 
 /**
- * Utility class, which simplifies creation of the Datastore properties.
+ * Utility class, which simplifies read/write operations on the Datastore properties.
  */
 final class DsProperties {
 
@@ -55,8 +55,18 @@ final class DsProperties {
         AggregateEventRecordProperty.created.setProperty(entity, toCloudTimestamp(when));
     }
 
+    static Timestamp whenCreated(Entity entity) {
+        com.google.cloud.Timestamp timestamp =
+                entity.getTimestamp(AggregateEventRecordProperty.created.toString());
+        return fromCloudTimestamp(timestamp);
+    }
+
     private static com.google.cloud.Timestamp toCloudTimestamp(Timestamp when) {
         return ofTimeSecondsAndNanos(when.getSeconds(), when.getNanos());
+    }
+
+    private static Timestamp fromCloudTimestamp(com.google.cloud.Timestamp when) {
+        return when.toProto();
     }
 
     static void addVersion(Entity.Builder entity, Version version) {
@@ -84,6 +94,11 @@ final class DsProperties {
     static boolean isDeleted(Entity entity) {
         checkNotNull(entity);
         return hasFlag(entity, deleted.toString());
+    }
+
+    static boolean isSnapshot(Entity entity) {
+        checkNotNull(entity);
+        return hasFlag(entity, AggregateEventRecordProperty.snapshot.toString());
     }
 
     static OrderBy byCreatedTime() {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsProperties.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsProperties.java
@@ -35,7 +35,7 @@ import static io.spine.server.storage.LifecycleFlagField.archived;
 import static io.spine.server.storage.LifecycleFlagField.deleted;
 
 /**
- * Utility class, which simplifies read/write operations on the Datastore properties.
+ * Utility class, which simplifies the read/write operations on the Datastore properties.
  */
 final class DsProperties {
 

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreStorageFactoryBuilderTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreStorageFactoryBuilderTest.java
@@ -152,8 +152,8 @@ class DatastoreStorageFactoryBuilderTest {
                     .setDatastore(options.getService())
                     .build();
             assertNotNull(factory);
-            String actualNamespace = factory.getDatastore()
-                                            .getDatastoreOptions()
+            String actualNamespace = factory.datastore()
+                                            .datastoreOptions()
                                             .getNamespace();
             assertEquals(namespace, actualNamespace);
         }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
@@ -348,7 +348,7 @@ class DatastoreWrapperTest {
         String tenantId2Prefixed = "Esecond-at-tenant.id";
         String tenantId3 = "third.id";
         String tenantId3Prefixed = "Dthird.id";
-        Datastore datastore = wrapper.getDatastore();
+        Datastore datastore = wrapper.datastore();
         ensureNamespace(tenantId1Prefixed, datastore);
         ensureNamespace(tenantId2Prefixed, datastore);
         ensureNamespace(tenantId3Prefixed, datastore);
@@ -419,7 +419,7 @@ class DatastoreWrapperTest {
         Key entityKey = new TenantAwareFunction0<Key>(tenantId) {
             @Override
             public Key apply() {
-                Key entityKey = wrapper.getKeyFactory(Kind.of(NAMESPACE_HOLDER_KIND))
+                Key entityKey = wrapper.keyFactory(Kind.of(NAMESPACE_HOLDER_KIND))
                                        .newKey(key);
                 Entity entity = Entity.newBuilder(entityKey)
                                       .build();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
@@ -203,8 +203,8 @@ class DsAggregateStorageTest extends AggregateStorageTest {
     }
 
     @Nested
-    @DisplayName("truncate itself")
-    class Truncate {
+    @DisplayName("truncate efficiently")
+    class TruncateEfficiently {
 
         private DsAggregateStorage<ProjectId> storage;
 
@@ -217,8 +217,8 @@ class DsAggregateStorageTest extends AggregateStorageTest {
         }
 
         @Test
-        @DisplayName("with minimum operations when having bulk of records stored")
-        void efficiently() {
+        @DisplayName("when having bulk of records stored")
+        void withBulkOfRecords() {
             ProjectId id = newId();
             AggregateHistory.Builder history = AggregateHistory.newBuilder();
             Version version = zero();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTruncationTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTruncationTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import io.spine.server.aggregate.AggregateStorageTruncationTest;
+import io.spine.server.storage.StorageFactory;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("DsAggregateStorage after truncation should")
+public class DsAggregateStorageTruncationTest extends AggregateStorageTruncationTest {
+
+    @Override
+    protected StorageFactory storageFactory() {
+        return TestDatastoreStorageFactory.defaultInstance();
+    }
+}

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -362,7 +362,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
 
         @BeforeEach
         void setUp() {
-            SpyStorageFactory.injectWrapper(datastoreFactory().getDatastore());
+            SpyStorageFactory.injectWrapper(datastoreFactory().datastore());
             storageFactory = new SpyStorageFactory();
             storage = storageFactory.createRecordStorage(CollegeEntity.class);
         }
@@ -584,7 +584,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             assertEquals(expectedCounts, actualCounts);
 
             // Check Datastore reads are performed by keys but not using a structured query.
-            DatastoreWrapper spy = storageFactory.getDatastore();
+            DatastoreWrapper spy = storageFactory.datastore();
             verify(spy).read(anyIterable());
             verify(spy, never()).read(any(StructuredQuery.class));
         }
@@ -693,7 +693,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
 
         @SuppressWarnings("unchecked") // For the purposes of mocking.
         private void assertDsReadByKeys() {
-            DatastoreWrapper spy = storageFactory.getDatastore();
+            DatastoreWrapper spy = storageFactory.datastore();
             verify(spy).read(anyIterable());
             verify(spy, never()).read(any(StructuredQuery.class));
         }
@@ -717,7 +717,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
 
         @BeforeEach
         void setUp() {
-            SpyStorageFactory.injectWrapper(datastoreFactory().getDatastore());
+            SpyStorageFactory.injectWrapper(datastoreFactory().datastore());
             storageFactory = new SpyStorageFactory();
             storage = storageFactory.createRecordStorage(CollegeEntity.class);
         }
@@ -1078,34 +1078,9 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
 
         @SuppressWarnings("unchecked") // For the purposes of mocking.
         private void assertDsReadByStructuredQuery(int invocationCount) {
-            DatastoreWrapper spy = storageFactory.getDatastore();
+            DatastoreWrapper spy = storageFactory.datastore();
             verify(spy, never()).read(anyIterable());
             verify(spy, times(invocationCount)).read(any(StructuredQuery.class));
-        }
-    }
-
-    /**
-     * A {@link TestDatastoreStorageFactory} which spies on its {@link DatastoreWrapper}.
-     *
-     * This class is not moved to the
-     * {@linkplain io.spine.server.storage.datastore.given.DsRecordStorageTestEnv test environment}
-     * because it uses package-private method of {@link DatastoreWrapper}.
-     */
-    private static class SpyStorageFactory extends TestDatastoreStorageFactory {
-
-        private static DatastoreWrapper spyWrapper = null;
-
-        private static void injectWrapper(DatastoreWrapper wrapper) {
-            spyWrapper = spy(wrapper);
-        }
-
-        private SpyStorageFactory() {
-            super(spyWrapper.getDatastore());
-        }
-
-        @Override
-        protected DatastoreWrapper createDatastoreWrapper(Builder builder) {
-            return spyWrapper;
         }
     }
 }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/SpyStorageFactory.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/SpyStorageFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * A {@link TestDatastoreStorageFactory} which spies on its {@link DatastoreWrapper}.
+ *
+ * This class is not moved to the
+ * {@linkplain io.spine.server.storage.datastore.given.DsRecordStorageTestEnv test environment}
+ * because it uses the package-private method of {@link DatastoreWrapper}.
+ */
+final class SpyStorageFactory extends TestDatastoreStorageFactory {
+
+    private static DatastoreWrapper spyWrapper = null;
+
+    static void injectWrapper(DatastoreWrapper wrapper) {
+        spyWrapper = spy(wrapper);
+    }
+
+    SpyStorageFactory() {
+        super(spyWrapper.datastore());
+    }
+
+    @Override
+    protected DatastoreWrapper createDatastoreWrapper(Builder builder) {
+        return spyWrapper;
+    }
+}

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TestDatastoreStorageFactory.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TestDatastoreStorageFactory.java
@@ -103,7 +103,7 @@ public class TestDatastoreStorageFactory extends DatastoreStorageFactory {
      * @see #tearDown()
      */
     public void clear() {
-        TestDatastoreWrapper datastore = (TestDatastoreWrapper) getDatastore();
+        TestDatastoreWrapper datastore = (TestDatastoreWrapper) datastore();
         try {
             datastore.dropAllTables();
         } catch (Throwable e) {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TestDatastoreWrapper.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TestDatastoreWrapper.java
@@ -69,9 +69,9 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
     }
 
     @Override
-    public KeyFactory getKeyFactory(Kind kind) {
+    public KeyFactory keyFactory(Kind kind) {
         kindsCache.add(kind.getValue());
-        return super.getKeyFactory(kind);
+        return super.keyFactory(kind);
     }
 
     @Override

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/DatastoreWrapperTestEnv.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/DatastoreWrapperTestEnv.java
@@ -49,7 +49,7 @@ public class DatastoreWrapperTestEnv {
         new TenantAwareOperation(tenantId) {
             @Override
             public void run() {
-                Key key = wrapper.getKeyFactory(GENERIC_ENTITY_KIND)
+                Key key = wrapper.keyFactory(GENERIC_ENTITY_KIND)
                                  .newKey(42L);
                 assertEquals(id, key.getNamespace());
             }


### PR DESCRIPTION
Part of https://github.com/SpineEventEngine/core-java/pull/1083.

This PR adds the functionality to drop redundant AggregateEventRecord instances from the storage.

The "cleaning" occurs on per-AggregateStorage basis, dropping the records which occur before the Nth snapshot for each entity. It's also possible to clip all records older than some date.

In the Datastore implementation, the cleaning mechanism first gathers the records for deletion and then deletes them batch-by-batch.

Also, the Travis build is now performed with OpenJDK 8.