### PR TITLE
Remove notion of a separately stored event count

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsAggregateStorage.java
@@ -338,11 +338,7 @@ public class DsAggregateStorage<I> extends AggregateStorage<I> {
 
     private Key toLifecycleRecordKey(I id) {
         RecordId recordId = toLifecycleRecordId(id);
-        return toLifecycleRecordKey(recordId);
-    }
-
-    private Key toLifecycleRecordKey(RecordId id) {
-        Key key = datastore.keyFor(Kind.of(AGGREGATE_LIFECYCLE_KIND), id);
+        Key key = datastore.keyFor(Kind.of(AGGREGATE_LIFECYCLE_KIND), recordId);
         return key;
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/RecordId.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/RecordId.java
@@ -22,6 +22,7 @@ package io.spine.server.storage.datastore;
 import io.spine.string.Stringifiers;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 
 /**
  * A wrapper type for the {@code String}-based record identifiers in the GAE Datastore.
@@ -56,5 +57,21 @@ final class RecordId extends DsIdentifier {
     static RecordId ofEntityId(Object id) {
         String idAsString = Stringifiers.toString(id);
         return of(idAsString);
+    }
+
+    /**
+     * Creates an instance of {@code RecordId} for a given {@link io.spine.server.entity.Entity}
+     * identifier using the specified prefix.
+     *
+     * @param id
+     *         an identifier of an {@code Entity}
+     * @param prefix
+     *         a prefix for the Datastore record identifier
+     * @return the Datastore record identifier
+     */
+    static RecordId withPrefix(Object id, String prefix) {
+        String idAsString = Stringifiers.toString(id);
+        String datastoreId = format("%s_%s", prefix, idAsString);
+        return of(datastoreId);
     }
 }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/RecordId.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/RecordId.java
@@ -60,13 +60,13 @@ final class RecordId extends DsIdentifier {
     }
 
     /**
-     * Creates an instance of {@code RecordId} for a given {@link io.spine.server.entity.Entity}
-     * identifier using the specified prefix.
+     * Creates an instance by combining a given {@link io.spine.server.entity.Entity}
+     * identifier along with the specified prefix.
      *
      * @param id
      *         an identifier of an {@code Entity}
      * @param prefix
-     *         a prefix for the Datastore record identifier
+     *         a prefix for the record identifier
      * @return the Datastore record identifier
      */
     static RecordId withPrefix(Object id, String prefix) {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
@@ -157,7 +157,7 @@ class DsAggregateStorageTest extends AggregateStorageTest {
 
     @SuppressWarnings("OptionalGetWithoutIsPresent") // Checked logically.
     @Test
-    @DisplayName("read the lifecycle flags stored in the old format")
+    @DisplayName("read lifecycle flags stored in the old format")
     void readLifecycleFlagsOldFormat() {
         DsAggregateStorage<ProjectId> storage = (DsAggregateStorage<ProjectId>) storage();
         ProjectId id = newId();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
@@ -96,8 +96,7 @@ class DsAggregateStorageTest extends AggregateStorageTest {
     }
 
     @Override
-    protected AggregateStorage<ProjectId>
-    newStorage(Class<? extends Entity<?, ?>> cls) {
+    protected AggregateStorage<ProjectId> newStorage(Class<? extends Entity<?, ?>> cls) {
         @SuppressWarnings("unchecked") // Logically checked; OK for test purposes.
                 Class<? extends Aggregate<ProjectId, ?, ?>> aggCls =
                 (Class<? extends Aggregate<ProjectId, ?, ?>>) cls;

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TestDatastoreStorageFactory.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TestDatastoreStorageFactory.java
@@ -90,7 +90,8 @@ public class TestDatastoreStorageFactory extends DatastoreStorageFactory {
      *
      * <p>May be effectively the same as {@link #clear()}.
      *
-     * <p>NOTE: does not stop the server but just deletes all records.
+     * <p><b>NOTE</b>: does not stop the server but just deletes all records.
+     *
      * <p>Equivalent to dropping all tables in an SQL-base storage.
      */
     public void tearDown() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/DsRecordStorageTestEnv.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/DsRecordStorageTestEnv.java
@@ -136,7 +136,7 @@ public class DsRecordStorageTestEnv {
     public static IdFilter newIdFilter(List<Any> targetIds) {
         return IdFilter
                 .newBuilder()
-                .addAllIds(targetIds)
+                .addAllId(targetIds)
                 .vBuild();
     }
 


### PR DESCRIPTION
This PR is a part of https://github.com/SpineEventEngine/core-java/pull/1089.

The `DsAggregateStorage` will no more store records for the event count after the last snapshot.

Also, the prefix under which aggregate lifecycle records are stored is fixed.