### PR TITLE
Return unique aggregate IDs from the `DsAggregateStorage.index()`

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -267,11 +267,11 @@ public class DatastoreWrapper implements Logging {
      * @param query
      *         {@link Query} to execute upon the Datastore
      * @param <E>
-     *         the type of queried entities
+     *         the type of queried objects
      * @return results fo the query as a lazily evaluated {@link Iterator}
      * @see DatastoreReader#run(Query)
      */
-    public <E extends BaseEntity<Key>> DsQueryIterator<E> read(StructuredQuery<E> query) {
+    public <E> DsQueryIterator<E> read(StructuredQuery<E> query) {
         Namespace namespace = currentNamespace();
         StructuredQuery<E> queryWithNamespace =
                 query.toBuilder()
@@ -295,12 +295,12 @@ public class DatastoreWrapper implements Logging {
      * @param pageSize
      *         a non-zero number of elements to be returned per a single read from Datastore
      * @param <E>
-     *         the type of queried entities
+     *         the type of queried objects
      * @return results fo the query as a lazily evaluated {@link Iterator}
      * @throws IllegalArgumentException
      *         if the provided {@linkplain StructuredQuery#getLimit() query includes a limit}
      */
-    <E extends BaseEntity<Key>> Iterator<E> readAll(StructuredQuery<E> query, int pageSize) {
+    <E> Iterator<E> readAll(StructuredQuery<E> query, int pageSize) {
         return readAllPageByPage(query, pageSize);
     }
 
@@ -316,12 +316,12 @@ public class DatastoreWrapper implements Logging {
      * @param query
      *         {@link Query} to execute upon the Datastore
      * @param <E>
-     *         the type of queried entities
+     *         the type of queried objects
      * @return results fo the query as a lazily evaluated {@link Iterator}
      * @throws IllegalArgumentException
      *         if the provided {@linkplain StructuredQuery#getLimit() query includes a limit}
      */
-    <E extends BaseEntity<Key>> Iterator<E> readAll(StructuredQuery<E> query) {
+    <E> Iterator<E> readAll(StructuredQuery<E> query) {
         return readAllPageByPage(query, null);
     }
 
@@ -340,14 +340,14 @@ public class DatastoreWrapper implements Logging {
      *         a non-zero number of elements to be returned per a single read from Datastore;
      *         if {@code null} the page size will be dictated by the Datastore
      * @param <E>
-     *         the type of queried entities
+     *         the type of queried objects
      * @return results fo the query as a lazily evaluated {@link Iterator}
      * @throws IllegalArgumentException
      *         if the provided {@linkplain StructuredQuery#getLimit() query includes a limit} or
      *         the provided {@code batchSize} is 0
      */
     @SuppressWarnings("unchecked") // Checked logically.
-    private <E extends BaseEntity<Key>> Iterator<E>
+    private <E> Iterator<E>
     readAllPageByPage(StructuredQuery<E> query, @Nullable Integer pageSize) {
         checkArgument(query.getLimit() == null,
                       "Cannot limit a number of entities for \"read all\" operation.");
@@ -360,7 +360,7 @@ public class DatastoreWrapper implements Logging {
                 .iterator();
     }
 
-    private static <E extends BaseEntity<Key>> StructuredQuery<E>
+    private static <E> StructuredQuery<E>
     limit(StructuredQuery<E> query, @Nullable Integer batchSize) {
         return batchSize == null
                ? query

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -271,7 +271,7 @@ public class DatastoreWrapper implements Logging {
      * @return results fo the query as a lazily evaluated {@link Iterator}
      * @see DatastoreReader#run(Query)
      */
-    public <E extends BaseEntity<?>> DsQueryIterator<E> read(StructuredQuery<E> query) {
+    public <E extends BaseEntity<Key>> DsQueryIterator<E> read(StructuredQuery<E> query) {
         Namespace namespace = currentNamespace();
         StructuredQuery<E> queryWithNamespace =
                 query.toBuilder()
@@ -300,7 +300,7 @@ public class DatastoreWrapper implements Logging {
      * @throws IllegalArgumentException
      *         if the provided {@linkplain StructuredQuery#getLimit() query includes a limit}
      */
-    <E extends BaseEntity<?>> Iterator<E> readAll(StructuredQuery<E> query, int pageSize) {
+    <E extends BaseEntity<Key>> Iterator<E> readAll(StructuredQuery<E> query, int pageSize) {
         return readAllPageByPage(query, pageSize);
     }
 
@@ -321,7 +321,7 @@ public class DatastoreWrapper implements Logging {
      * @throws IllegalArgumentException
      *         if the provided {@linkplain StructuredQuery#getLimit() query includes a limit}
      */
-    <E extends BaseEntity<?>> Iterator<E> readAll(StructuredQuery<E> query) {
+    <E extends BaseEntity<Key>> Iterator<E> readAll(StructuredQuery<E> query) {
         return readAllPageByPage(query, null);
     }
 
@@ -347,7 +347,7 @@ public class DatastoreWrapper implements Logging {
      *         the provided {@code batchSize} is 0
      */
     @SuppressWarnings("unchecked") // Checked logically.
-    private <E extends BaseEntity<?>> Iterator<E>
+    private <E extends BaseEntity<Key>> Iterator<E>
     readAllPageByPage(StructuredQuery<E> query, @Nullable Integer pageSize) {
         checkArgument(query.getLimit() == null,
                       "Cannot limit a number of entities for \"read all\" operation.");
@@ -360,7 +360,7 @@ public class DatastoreWrapper implements Logging {
                 .iterator();
     }
 
-    private static <E extends BaseEntity<?>> StructuredQuery<E>
+    private static <E extends BaseEntity<Key>> StructuredQuery<E>
     limit(StructuredQuery<E> query, @Nullable Integer batchSize) {
         return batchSize == null
                ? query

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -360,8 +360,8 @@ public class DatastoreWrapper implements Logging {
                 .iterator();
     }
 
-    private static <E> StructuredQuery<E>
-    limit(StructuredQuery<E> query, @Nullable Integer batchSize) {
+    private static <E> StructuredQuery<E> limit(StructuredQuery<E> query,
+                                                @Nullable Integer batchSize) {
         return batchSize == null
                ? query
                : query.toBuilder()

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
@@ -44,20 +44,20 @@ import java.util.NoSuchElementException;
  *
  * <p>The {@link #remove() remove()} method throws an {@link UnsupportedOperationException}.
  *
- * @param <E>
+ * @param <R>
  *         the type of queried objects
  */
-final class DsQueryIterator<E> extends UnmodifiableIterator<E> {
+final class DsQueryIterator<R> extends UnmodifiableIterator<R> {
 
-    private final StructuredQuery<E> query;
-    private final QueryResults<E> currentPage;
+    private final StructuredQuery<R> query;
+    private final QueryResults<R> currentPage;
 
     private final Integer limit;
     private int readCount = 0;
 
     private boolean terminated;
 
-    DsQueryIterator(StructuredQuery<E> query, DatastoreReaderWriter datastore) {
+    DsQueryIterator(StructuredQuery<R> query, DatastoreReaderWriter datastore) {
         super();
         this.query = query;
         this.limit = query.getLimit();
@@ -94,9 +94,9 @@ final class DsQueryIterator<E> extends UnmodifiableIterator<E> {
      * <p>The query is built utilizing the {@linkplain Cursor Datastore Cursor} from the current
      * query results.
      */
-    StructuredQuery<E> nextPageQuery() {
+    StructuredQuery<R> nextPageQuery() {
         Cursor cursorAfter = currentPage.getCursorAfter();
-        StructuredQuery<E> queryForMoreResults =
+        StructuredQuery<R> queryForMoreResults =
                 query.toBuilder()
                      .setStartCursor(cursorAfter)
                      .build();
@@ -104,11 +104,11 @@ final class DsQueryIterator<E> extends UnmodifiableIterator<E> {
     }
 
     @Override
-    public E next() {
+    public R next() {
         if (!hasNext()) {
             throw new NoSuchElementException("The query results Iterator is empty.");
         }
-        E result = currentPage.next();
+        R result = currentPage.next();
         readCount++;
         return result;
     }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
@@ -20,9 +20,9 @@
 
 package io.spine.server.storage.datastore;
 
+import com.google.cloud.datastore.BaseEntity;
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.DatastoreReaderWriter;
-import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 import com.google.common.collect.UnmodifiableIterator;
@@ -44,18 +44,21 @@ import java.util.NoSuchElementException;
  * <p>A call to {@link #next() next()} may not cause a Datastore query.
  *
  * <p>The {@link #remove() remove()} method throws an {@link UnsupportedOperationException}.
+ *
+ * @param <E>
+ *         the type of queried entities
  */
-final class DsQueryIterator extends UnmodifiableIterator<Entity> {
+final class DsQueryIterator<E extends BaseEntity<?>> extends UnmodifiableIterator<E> {
 
-    private final StructuredQuery<Entity> query;
-    private final QueryResults<Entity> currentPage;
+    private final StructuredQuery<E> query;
+    private final QueryResults<E> currentPage;
 
     private final Integer limit;
     private int readCount = 0;
 
     private boolean terminated;
 
-    DsQueryIterator(StructuredQuery<Entity> query, DatastoreReaderWriter datastore) {
+    DsQueryIterator(StructuredQuery<E> query, DatastoreReaderWriter datastore) {
         super();
         this.query = query;
         this.limit = query.getLimit();
@@ -92,9 +95,9 @@ final class DsQueryIterator extends UnmodifiableIterator<Entity> {
      * <p>The query is built utilizing the {@linkplain Cursor Datastore Cursor} from the current
      * query results.
      */
-    StructuredQuery<Entity> nextPageQuery() {
+    StructuredQuery<E> nextPageQuery() {
         Cursor cursorAfter = currentPage.getCursorAfter();
-        StructuredQuery<Entity> queryForMoreResults =
+        StructuredQuery<E> queryForMoreResults =
                 query.toBuilder()
                      .setStartCursor(cursorAfter)
                      .build();
@@ -102,11 +105,11 @@ final class DsQueryIterator extends UnmodifiableIterator<Entity> {
     }
 
     @Override
-    public Entity next() {
+    public E next() {
         if (!hasNext()) {
             throw new NoSuchElementException("The query results Iterator is empty.");
         }
-        Entity result = currentPage.next();
+        E result = currentPage.next();
         readCount++;
         return result;
     }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
@@ -23,6 +23,7 @@ package io.spine.server.storage.datastore;
 import com.google.cloud.datastore.BaseEntity;
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.DatastoreReaderWriter;
+import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 import com.google.common.collect.UnmodifiableIterator;
@@ -48,7 +49,7 @@ import java.util.NoSuchElementException;
  * @param <E>
  *         the type of queried entities
  */
-final class DsQueryIterator<E extends BaseEntity<?>> extends UnmodifiableIterator<E> {
+final class DsQueryIterator<E extends BaseEntity<Key>> extends UnmodifiableIterator<E> {
 
     private final StructuredQuery<E> query;
     private final QueryResults<E> currentPage;

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
@@ -20,10 +20,8 @@
 
 package io.spine.server.storage.datastore;
 
-import com.google.cloud.datastore.BaseEntity;
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.DatastoreReaderWriter;
-import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 import com.google.common.collect.UnmodifiableIterator;
@@ -47,9 +45,9 @@ import java.util.NoSuchElementException;
  * <p>The {@link #remove() remove()} method throws an {@link UnsupportedOperationException}.
  *
  * @param <E>
- *         the type of queried entities
+ *         the type of queried objects
  */
-final class DsQueryIterator<E extends BaseEntity<Key>> extends UnmodifiableIterator<E> {
+final class DsQueryIterator<E> extends UnmodifiableIterator<E> {
 
     private final StructuredQuery<E> query;
     private final QueryResults<E> currentPage;

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
@@ -21,6 +21,7 @@
 package io.spine.server.storage.datastore;
 
 import com.google.cloud.datastore.BaseEntity;
+import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StructuredQuery;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,7 +44,7 @@ import java.util.NoSuchElementException;
  * @param <E>
  *         the type of queried entities
  */
-final class DsQueryPageIterator<E extends BaseEntity<?>> implements Iterator<DsQueryIterator> {
+final class DsQueryPageIterator<E extends BaseEntity<Key>> implements Iterator<DsQueryIterator> {
 
     private final DatastoreWrapper datastore;
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
@@ -39,17 +39,17 @@ import java.util.NoSuchElementException;
  * <p>If the limit is not specified, then the page size is determined by the Datastore
  * query restrictions.
  *
- * @param <E>
+ * @param <R>
  *         the type of queried objects
  */
-final class DsQueryPageIterator<E> implements Iterator<DsQueryIterator> {
+final class DsQueryPageIterator<R> implements Iterator<DsQueryIterator> {
 
     private final DatastoreWrapper datastore;
 
-    private DsQueryIterator<E> currentPage;
-    private @Nullable DsQueryIterator<E> nextPage;
+    private DsQueryIterator<R> currentPage;
+    private @Nullable DsQueryIterator<R> nextPage;
 
-    DsQueryPageIterator(StructuredQuery<E> query, DatastoreWrapper datastore) {
+    DsQueryPageIterator(StructuredQuery<R> query, DatastoreWrapper datastore) {
         this.datastore = datastore;
         this.currentPage = datastore.read(query);
     }
@@ -63,7 +63,7 @@ final class DsQueryPageIterator<E> implements Iterator<DsQueryIterator> {
     }
 
     @Override
-    public DsQueryIterator<E> next() {
+    public DsQueryIterator<R> next() {
         if (nextPage == null) {
             currentPage = loadNextPage();
         } else {
@@ -76,8 +76,8 @@ final class DsQueryPageIterator<E> implements Iterator<DsQueryIterator> {
         return currentPage;
     }
 
-    private DsQueryIterator<E> loadNextPage() {
-        StructuredQuery<E> nextPageQuery = currentPage.nextPageQuery();
+    private DsQueryIterator<R> loadNextPage() {
+        StructuredQuery<R> nextPageQuery = currentPage.nextPageQuery();
         return datastore.read(nextPageQuery);
     }
 }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
@@ -20,8 +20,6 @@
 
 package io.spine.server.storage.datastore;
 
-import com.google.cloud.datastore.BaseEntity;
-import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StructuredQuery;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -42,9 +40,9 @@ import java.util.NoSuchElementException;
  * query restrictions.
  *
  * @param <E>
- *         the type of queried entities
+ *         the type of queried objects
  */
-final class DsQueryPageIterator<E extends BaseEntity<Key>> implements Iterator<DsQueryIterator> {
+final class DsQueryPageIterator<E> implements Iterator<DsQueryIterator> {
 
     private final DatastoreWrapper datastore;
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
@@ -20,7 +20,7 @@
 
 package io.spine.server.storage.datastore;
 
-import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.BaseEntity;
 import com.google.cloud.datastore.StructuredQuery;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -39,15 +39,18 @@ import java.util.NoSuchElementException;
  *
  * <p>If the limit is not specified, then the page size is determined by the Datastore
  * query restrictions.
+ *
+ * @param <E>
+ *         the type of queried entities
  */
-final class DsQueryPageIterator implements Iterator<DsQueryIterator> {
+final class DsQueryPageIterator<E extends BaseEntity<?>> implements Iterator<DsQueryIterator> {
 
     private final DatastoreWrapper datastore;
 
-    private DsQueryIterator currentPage;
-    private @Nullable DsQueryIterator nextPage;
+    private DsQueryIterator<E> currentPage;
+    private @Nullable DsQueryIterator<E> nextPage;
 
-    DsQueryPageIterator(StructuredQuery<Entity> query, DatastoreWrapper datastore) {
+    DsQueryPageIterator(StructuredQuery<E> query, DatastoreWrapper datastore) {
         this.datastore = datastore;
         this.currentPage = datastore.read(query);
     }
@@ -61,7 +64,7 @@ final class DsQueryPageIterator implements Iterator<DsQueryIterator> {
     }
 
     @Override
-    public DsQueryIterator next() {
+    public DsQueryIterator<E> next() {
         if (nextPage == null) {
             currentPage = loadNextPage();
         } else {
@@ -74,8 +77,8 @@ final class DsQueryPageIterator implements Iterator<DsQueryIterator> {
         return currentPage;
     }
 
-    private DsQueryIterator loadNextPage() {
-        StructuredQuery<Entity> nextPageQuery = currentPage.nextPageQuery();
+    private DsQueryIterator<E> loadNextPage() {
+        StructuredQuery<E> nextPageQuery = currentPage.nextPageQuery();
         return datastore.read(nextPageQuery);
     }
 }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/Indexes.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/Indexes.java
@@ -72,8 +72,7 @@ final class Indexes {
         return idIterator;
     }
 
-    private static <I> Function<Key, @Nullable I>
-    idExtractor(Class<I> idType) {
+    private static <I> Function<Key, @Nullable I> idExtractor(Class<I> idType) {
         return key -> {
             checkNotNull(key);
             String stringId = key.getName();

--- a/license-report.md
+++ b/license-report.md
@@ -578,10 +578,10 @@
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -698,9 +698,9 @@
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.2
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+     * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
@@ -710,9 +710,9 @@
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.2
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+     * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
 1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
      * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
@@ -780,7 +780,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 16:54:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 02 19:17:57 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1347,10 +1347,10 @@ This report was generated on **Thu Jul 25 16:54:10 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -1467,9 +1467,9 @@ This report was generated on **Thu Jul 25 16:54:10 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.2
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+     * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
@@ -1479,9 +1479,9 @@ This report was generated on **Thu Jul 25 16:54:10 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.2
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+     * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
 1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
      * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
@@ -1549,4 +1549,4 @@ This report was generated on **Thu Jul 25 16:54:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 16:54:11 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 02 19:18:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/version.gradle
+++ b/version.gradle
@@ -28,8 +28,8 @@
 def final SPINE_VERSION = '1.0.0-SNAPSHOT'
 
 ext {
-    spineBaseVersion = SPINE_VERSION
-    spineCoreVersion = SPINE_VERSION
+    spineBaseVersion = '1.0.0'
+    spineCoreVersion = '1.0.0'
 
     datastoreVersion = '1.61.0'
 


### PR DESCRIPTION
This PR fixes the work of the `DsAggregateStorage.index()` method.

Previously, the method returned a lot of repetitive aggregate IDs, returning an ID for each `AggregateEventRecord` found in the storage. Now, the method will return only unique aggregate IDs.

This is done with the help of Datastore `ProjectionEntityQuery`.

As the `DatastoreWrapper` now supports structured queries for arbitrary objects (and not only `StructuredQuery<Entity>`), the `DsRecordStorage` index was also migrated - to Datastore `KeyQuery` to avoid consuming additional entity read operations.

The `core` and `base` dependencies are bumped to `1.0.0` to fetch the corresponding `AggregateStorage` [test](https://github.com/SpineEventEngine/core-java/pull/1133).