### PR TITLE
Delivery improvements

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
@@ -81,6 +81,7 @@ public class DsInboxStorage
         EntityQuery.Builder builder =
                 Query.newEntityQueryBuilder()
                      .setFilter(eq(Column.shardIndex.columnName(), index.getIndex()))
+                     .setFilter(eq(Column.ofTotalShards.columnName(), index.getOfTotal()))
                      .setOrderBy(asc(Column.whenReceived.columnName()));
         Iterator<InboxMessage> iterator = readAll(builder, readBatchSize);
         return new InboxPage(iterator, readBatchSize);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -26,7 +26,6 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.TimestampValue;
 import com.google.common.collect.ImmutableList;
-import io.spine.annotation.SPI;
 import io.spine.logging.Logging;
 import io.spine.server.NodeId;
 import io.spine.server.delivery.ShardIndex;
@@ -143,7 +142,6 @@ public class DsShardedWorkRegistry
                                  .vBuild();
     }
 
-    @SPI
     protected ImmutableList<ShardSessionRecord> readByIndex(ShardIndex index) {
         EntityQuery.Builder query =
                 Query.newEntityQueryBuilder()

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -72,7 +72,7 @@ public class DsShardedWorkRegistry
     }
 
     @Override
-    public Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
+    public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
         checkNotNull(index);
         checkNotNull(nodeId);
 

--- a/version.gradle
+++ b/version.gradle
@@ -28,7 +28,7 @@
 def final SPINE_VERSION = '1.0.1'
 
 ext {
-    versionToPublish = '1.0.2'
+    versionToPublish = '1.0.3-SNAPSHOT'
     
     spineBaseVersion = SPINE_VERSION
     spineCoreVersion = SPINE_VERSION


### PR DESCRIPTION
This changeset adds some precautions to using `DsShardedWorkRegistry` in a multi-node environment:

1. The shard index is now read using both the index value and the total number of shards. It prevents from confusing the indexes such as "1 of 10" and "1 of 42" with each other.
2. After picking up the session we now verify that this node has indeed written the contents to the registry.
3. The `pickUp()` call is now synchronized to avoid extra I/O of reading/writing the concurrent session records from the same instance.