### PR TITLE
Release only non-empty sessions

### DIFF
--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsSessionStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsSessionStorage.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import com.google.cloud.datastore.LongValue;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.StringValue;
+import com.google.cloud.datastore.TimestampValue;
+import io.spine.server.delivery.ShardIndex;
+import io.spine.server.delivery.ShardSessionRecord;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+import static com.google.cloud.Timestamp.fromProto;
+import static io.spine.server.storage.datastore.DatastoreWrapper.MAX_ENTITIES_PER_WRITE_REQUEST;
+
+/**
+ * A Datastore-based storage which contains {@code ShardSessionRecord}s.
+ */
+public final class DsSessionStorage
+        extends DsMessageStorage<ShardIndex, ShardSessionRecord, ShardSessionReadRequest> {
+
+    private static final boolean multitenant = false;
+
+    DsSessionStorage(DatastoreStorageFactory factory) {
+        super(factory.systemWrapperFor(DsSessionStorage.class, multitenant), multitenant);
+    }
+
+    @Override
+    ShardIndex idOf(ShardSessionRecord message) {
+        return message.getIndex();
+    }
+
+    @Override
+    MessageColumn<ShardSessionRecord>[] columns() {
+        return Column.values();
+    }
+
+    /**
+     * Obtains all the session records present in the storage.
+     */
+    Iterator<ShardSessionRecord> readAll() {
+        return readAll(Query.newEntityQueryBuilder(), MAX_ENTITIES_PER_WRITE_REQUEST);
+    }
+
+    /**
+     * Obtains the session record for the shard with the given index.
+     */
+    Optional<ShardSessionRecord> read(ShardIndex index) {
+        return read(new ShardSessionReadRequest(index));
+    }
+
+    /**
+     * The columns of the {@link ShardSessionRecord} message stored in Datastore.
+     */
+    private enum Column implements MessageColumn<ShardSessionRecord> {
+
+        shardIndex("work_shard", (m) -> {
+            return LongValue.of(m.getIndex()
+                                 .getIndex());
+        }),
+
+        ofTotalShards("of_total_work_shards", (m) -> {
+            return LongValue.of(m.getIndex()
+                                 .getOfTotal());
+        }),
+
+        nodeId("nodeId", (m) -> {
+            return StringValue.of(m.getPickedBy()
+                                   .getValue());
+        }),
+
+        whenLastPicked("when_last_picked", (m) -> {
+            return TimestampValue.of(fromProto(m.getWhenLastPicked()));
+        });
+
+        /**
+         * The column name.
+         */
+        private final String name;
+
+        /**
+         * Obtains the value of the column from the given message.
+         */
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")  // This enum isn't serialized.
+        private final Getter<ShardSessionRecord> getter;
+
+        Column(String name,
+               Getter<ShardSessionRecord> getter) {
+            this.name = name;
+            this.getter = getter;
+        }
+
+        @Override
+        public String columnName() {
+            return name;
+        }
+
+        @Override
+        public Getter<ShardSessionRecord> getter() {
+            return getter;
+        }
+    }
+}

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsSessionStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsSessionStorage.java
@@ -74,45 +74,37 @@ public final class DsSessionStorage
      */
     private enum Column implements MessageColumn<ShardSessionRecord> {
 
-        shardIndex("work_shard", (m) -> {
+        shard((m) -> {
             return LongValue.of(m.getIndex()
                                  .getIndex());
         }),
 
-        ofTotalShards("of_total_work_shards", (m) -> {
+        total_shards((m) -> {
             return LongValue.of(m.getIndex()
                                  .getOfTotal());
         }),
 
-        nodeId("nodeId", (m) -> {
+        node((m) -> {
             return StringValue.of(m.getPickedBy()
                                    .getValue());
         }),
 
-        whenLastPicked("when_last_picked", (m) -> {
+        when_last_picked((m) -> {
             return TimestampValue.of(fromProto(m.getWhenLastPicked()));
         });
 
         /**
-         * The column name.
-         */
-        private final String name;
-
-        /**
          * Obtains the value of the column from the given message.
          */
-        @SuppressWarnings("NonSerializableFieldInSerializableClass")  // This enum isn't serialized.
         private final Getter<ShardSessionRecord> getter;
 
-        Column(String name,
-               Getter<ShardSessionRecord> getter) {
-            this.name = name;
+        Column(Getter<ShardSessionRecord> getter) {
             this.getter = getter;
         }
 
         @Override
         public String columnName() {
-            return name;
+            return name();
         }
 
         @Override

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -101,13 +101,15 @@ public class DsShardedWorkRegistry
         ImmutableList<ShardSessionRecord> allRecords = readAll();
         ImmutableList.Builder<ShardIndex> resultBuilder = ImmutableList.builder();
         for (ShardSessionRecord record : allRecords) {
-            Timestamp whenPicked = record.getWhenLastPicked();
-            Duration elapsed = between(whenPicked, currentTime());
+            if (record.hasPickedBy()) {
+                Timestamp whenPicked = record.getWhenLastPicked();
+                Duration elapsed = between(whenPicked, currentTime());
 
-            int comparison = Durations.compare(elapsed, inactivityPeriod);
-            if (comparison >= 0) {
-                clearNode(record);
-                resultBuilder.add(record.getIndex());
+                int comparison = Durations.compare(elapsed, inactivityPeriod);
+                if (comparison >= 0) {
+                    clearNode(record);
+                    resultBuilder.add(record.getIndex());
+                }
             }
         }
         return resultBuilder.build();

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -64,7 +64,14 @@ public class DsShardedWorkRegistry
 
     @Override
     public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
-        return super.pickUp(index, nodeId);
+        Optional<ShardProcessingSession> picked = super.pickUp(index, nodeId);
+        return picked.filter(session -> pickedBy(index, nodeId));
+    }
+
+    private boolean pickedBy(ShardIndex index, NodeId nodeId) {
+        Optional<ShardSessionRecord> stored = find(index);
+        return stored.map(record -> record.getPickedBy().equals(nodeId))
+                     .orElse(false);
     }
 
     @Override

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -20,35 +20,21 @@
 
 package io.spine.server.storage.datastore;
 
-import com.google.cloud.datastore.EntityQuery;
-import com.google.cloud.datastore.LongValue;
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.StringValue;
-import com.google.cloud.datastore.TimestampValue;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Durations;
 import io.spine.logging.Logging;
 import io.spine.server.NodeId;
+import io.spine.server.delivery.AbstractWorkRegistry;
 import io.spine.server.delivery.ShardIndex;
 import io.spine.server.delivery.ShardProcessingSession;
 import io.spine.server.delivery.ShardSessionRecord;
-import io.spine.server.delivery.ShardedWorkRegistry;
-import io.spine.string.Stringifiers;
 
 import java.util.Iterator;
 import java.util.Optional;
 
-import static com.google.cloud.Timestamp.fromProto;
-import static com.google.cloud.datastore.StructuredQuery.PropertyFilter.eq;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.protobuf.util.Timestamps.between;
-import static io.spine.base.Time.currentTime;
-import static io.spine.server.storage.datastore.DatastoreWrapper.MAX_ENTITIES_PER_WRITE_REQUEST;
 
 /**
- * A {@link ShardedWorkRegistry} based on the Google Datastore storage.
+ * A {@link io.spine.server.delivery.ShardedWorkRegistry} based on the Google Datastore storage.
  *
  * <p>The sharded work is stored as {@link ShardSessionRecord}s in the Datastore. Each time
  * the session is {@linkplain #pickUp(ShardIndex, NodeId) picked up}, the corresponding
@@ -58,10 +44,10 @@ import static io.spine.server.storage.datastore.DatastoreWrapper.MAX_ENTITIES_PE
  * as it provides the strong consistency for queries.
  */
 public class DsShardedWorkRegistry
-        extends DsMessageStorage<ShardIndex, ShardSessionRecord, ShardSessionReadRequest>
-        implements ShardedWorkRegistry, Logging {
+        extends AbstractWorkRegistry
+        implements Logging {
 
-    private static final boolean multitenant = false;
+    private final DsSessionStorage storage;
 
     /**
      * Creates an instance of registry using the {@link DatastoreStorageFactory} passed.
@@ -71,165 +57,48 @@ public class DsShardedWorkRegistry
      * by tenant.
      */
     public DsShardedWorkRegistry(DatastoreStorageFactory factory) {
-        super(factory.systemWrapperFor(DsShardedWorkRegistry.class, multitenant), multitenant);
+        super();
+        checkNotNull(factory);
+        this.storage = new DsSessionStorage(factory);
     }
 
     @Override
     public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
-        checkNotNull(index);
-        checkNotNull(nodeId);
-
-        boolean pickedAlready = isPickedAlready(index);
-        if (pickedAlready) {
-            return Optional.empty();
-        }
-        ShardSessionRecord ssr = newRecord(index, nodeId);
-        write(ssr);
-        boolean writeConsistent = checkConsistency(index, ssr);
-        if (writeConsistent) {
-            ShardProcessingSession result = new DsShardProcessingSession(ssr, () -> clearNode(ssr));
-            return Optional.of(result);
-        } else {
-            return Optional.empty();
-        }
+        return super.pickUp(index, nodeId);
     }
 
     @Override
-    public Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
-        checkNotNull(inactivityPeriod);
-
-        ImmutableList<ShardSessionRecord> allRecords = readAll();
-        ImmutableList.Builder<ShardIndex> resultBuilder = ImmutableList.builder();
-        for (ShardSessionRecord record : allRecords) {
-            if (record.hasPickedBy()) {
-                Timestamp whenPicked = record.getWhenLastPicked();
-                Duration elapsed = between(whenPicked, currentTime());
-
-                int comparison = Durations.compare(elapsed, inactivityPeriod);
-                if (comparison >= 0) {
-                    clearNode(record);
-                    resultBuilder.add(record.getIndex());
-                }
-            }
-        }
-        return resultBuilder.build();
-    }
-
-    private ImmutableList<ShardSessionRecord> readAll() {
-        EntityQuery.Builder query = Query.newEntityQueryBuilder();
-        Iterator<ShardSessionRecord> iterator = readAll(query, MAX_ENTITIES_PER_WRITE_REQUEST);
-        return ImmutableList.copyOf(iterator);
-    }
-
-    private boolean checkConsistency(ShardIndex index, ShardSessionRecord ssr) {
-        ImmutableList<ShardSessionRecord> records = readByIndex(index);
-        if (records.size() > 1) {
-            _warn().log("Several `ShardSessionRecord`s found for index %s.",
-                        Stringifiers.toString(index));
-        }
-        ShardSessionRecord fromStorage = records.iterator()
-                                                .next();
-        return fromStorage.equals(ssr);
-    }
-
-    /**
-     * Clears the {@linkplain ShardSessionRecord#getPickedBy() node} of the passed session and
-     * updates the record in the storage.
-     */
-    private void clearNode(ShardSessionRecord record) {
-        ShardSessionRecord updated = record.toBuilder()
-                                           .clearPickedBy()
-                                           .vBuild();
-        write(updated);
-    }
-
-    /**
-     * Tells if the session with the passed index is currently picked by any node.
-     */
-    private boolean isPickedAlready(ShardIndex index) {
-        ImmutableList<ShardSessionRecord> records = readByIndex(index);
-        long nodesWithShard = records
-                .stream()
-                .filter(ShardSessionRecord::hasPickedBy)
-                .count();
-        return nodesWithShard > 0;
+    public synchronized Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
+        return super.releaseExpiredSessions(inactivityPeriod);
     }
 
     @Override
-    ShardIndex idOf(ShardSessionRecord message) {
-        return message.getIndex();
+    protected synchronized void clearNode(ShardSessionRecord session) {
+        super.clearNode(session);
     }
 
     @Override
-    MessageColumn<ShardSessionRecord>[] columns() {
-        return Column.values();
+    protected Iterator<ShardSessionRecord> allRecords() {
+        return storage().readAll();
     }
 
-    private static ShardSessionRecord newRecord(ShardIndex index, NodeId nodeId) {
-        return ShardSessionRecord.newBuilder()
-                                 .setIndex(index)
-                                 .setPickedBy(nodeId)
-                                 .setWhenLastPicked(currentTime())
-                                 .vBuild();
+    @Override
+    protected void write(ShardSessionRecord session) {
+        storage().write(session);
     }
 
-    protected ImmutableList<ShardSessionRecord> readByIndex(ShardIndex index) {
-        EntityQuery.Builder query =
-                Query.newEntityQueryBuilder()
-                     .setFilter(eq(Column.shardIndex.columnName(), index.getIndex()));
-        Iterator<ShardSessionRecord> iterator = readAll(query, MAX_ENTITIES_PER_WRITE_REQUEST);
-        return ImmutableList.copyOf(iterator);
+    @Override
+    protected Optional<ShardSessionRecord> find(ShardIndex index) {
+        Optional<ShardSessionRecord> read = storage().read(index);
+        return read;
     }
 
-    /**
-     * The columns of the {@link ShardSessionRecord} message stored in Datastore.
-     */
-    private enum Column implements MessageColumn<ShardSessionRecord> {
+    @Override
+    protected ShardProcessingSession asSession(ShardSessionRecord record) {
+        return new DsShardProcessingSession(record, () -> clearNode(record));
+    }
 
-        shardIndex("work_shard", (m) -> {
-            return LongValue.of(m.getIndex()
-                                 .getIndex());
-        }),
-
-        ofTotalShards("of_total_work_shards", (m) -> {
-            return LongValue.of(m.getIndex()
-                                 .getOfTotal());
-        }),
-
-        nodeId("nodeId", (m) -> {
-            return StringValue.of(m.getPickedBy()
-                                   .getValue());
-        }),
-
-        whenLastPicked("when_last_picked", (m) -> {
-            return TimestampValue.of(fromProto(m.getWhenLastPicked()));
-        });
-
-        /**
-         * The column name.
-         */
-        private final String name;
-
-        /**
-         * Obtains the value of the column from the given message.
-         */
-        @SuppressWarnings("NonSerializableFieldInSerializableClass")  // This enum isn't serialized.
-        private final Getter<ShardSessionRecord> getter;
-
-        Column(String name,
-               Getter<ShardSessionRecord> getter) {
-            this.name = name;
-            this.getter = getter;
-        }
-
-        @Override
-        public String columnName() {
-            return name;
-        }
-
-        @Override
-        public Getter<ShardSessionRecord> getter() {
-            return getter;
-        }
+    protected DsSessionStorage storage() {
+        return storage;
     }
 }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -62,6 +62,13 @@ public class DsShardedWorkRegistry
         this.storage = new DsSessionStorage(factory);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>When picking up a shard, performs a double check to ensure that the write into database
+     * was not overridden by another node. If the write was overridden, gives up the shard to
+     * the other node and returns {@code Optional.empty()}.
+     */
     @Override
     public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
         Optional<ShardProcessingSession> picked = super.pickUp(index, nodeId);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -112,6 +112,9 @@ public class DsShardedWorkRegistry
         return new DsShardProcessingSession(record, () -> clearNode(record));
     }
 
+    /**
+     * Obtains the session storage which persists the session records.
+     */
     protected DsSessionStorage storage() {
         return storage;
     }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsShardedWorkRegistryTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsShardedWorkRegistryTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.datastore;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.server.storage.datastore.given.TestShardIndex.newIndex;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -144,11 +144,9 @@ class DsShardedWorkRegistryTest extends ShardedWorkRegistryTest {
     }
 
     private ShardSessionRecord readSingleRecord(ShardIndex index) {
-        ImmutableList<ShardSessionRecord> records = registry.readByIndex(index);
-        assertThat(records.size()).isEqualTo(1);
-
-        return records.iterator()
-                      .next();
+        Optional<ShardSessionRecord> record = registry.storage().read(index);
+        assertThat(record).isPresent();
+        return record.get();
     }
 
     private static NodeId newNode() {

--- a/license-report.md
+++ b/license-report.md
@@ -762,7 +762,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 16:15:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 16:22:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1531,4 +1531,4 @@ This report was generated on **Thu Sep 05 16:15:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 16:15:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 16:22:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.0.3`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -88,7 +88,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -215,7 +215,7 @@
      * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -362,12 +362,12 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.1-jre
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
@@ -629,7 +629,7 @@
      * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -762,12 +762,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:34:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 18:44:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.0.3`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
@@ -850,7 +850,7 @@ This report was generated on **Sun Sep 01 13:34:28 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -979,7 +979,7 @@ This report was generated on **Sun Sep 01 13:34:28 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1121,12 +1121,12 @@ This report was generated on **Sun Sep 01 13:34:28 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.1-jre
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
@@ -1398,7 +1398,7 @@ This report was generated on **Sun Sep 01 13:34:28 EEST 2019** using [Gradle-Lic
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1531,4 +1531,4 @@ This report was generated on **Sun Sep 01 13:34:28 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:34:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 18:44:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.0.7-SNAPSHOT`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -762,12 +762,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 16:22:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 16:27:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.0.7-SNAPSHOT`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
@@ -1531,4 +1531,4 @@ This report was generated on **Thu Sep 05 16:22:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 16:22:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 16:27:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -762,7 +762,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 18:44:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:42:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1531,4 +1531,4 @@ This report was generated on **Wed Sep 04 18:44:54 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 18:44:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:42:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -762,7 +762,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 15:42:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 16:15:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1531,4 +1531,4 @@ This report was generated on **Thu Sep 05 15:42:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 15:42:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 16:15:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.0.7-SNAPSHOT</version>
+<version>1.0.8-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,7 +40,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -58,7 +58,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -126,12 +126,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.0.3</version>
+<version>1.0.7-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,13 +40,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.7-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-testlib</artifactId>
-    <version>28.0-jre</version>
+    <version>28.1-jre</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -58,7 +58,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.7-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle
+++ b/version.gradle
@@ -25,12 +25,12 @@
  * {@code .config/gradle/dependencies.gradle}.
  */
 
-def final SPINE_VERSION = '1.0.3'
+def final SPINE_VERSION = '1.0.7-SNAPSHOT'
 
 ext {
     versionToPublish = SPINE_VERSION
     
-    spineBaseVersion = SPINE_VERSION
+    spineBaseVersion = '1.0.3'
     spineCoreVersion = SPINE_VERSION
 
     datastoreVersion = '1.87.0'

--- a/version.gradle
+++ b/version.gradle
@@ -25,12 +25,12 @@
  * {@code .config/gradle/dependencies.gradle}.
  */
 
-def final SPINE_VERSION = '1.0.7-SNAPSHOT'
+def final SPINE_VERSION = '1.0.8-SNAPSHOT'
 
 ext {
     versionToPublish = SPINE_VERSION
     
-    spineBaseVersion = '1.0.3'
+    spineBaseVersion = SPINE_VERSION
     spineCoreVersion = SPINE_VERSION
 
     datastoreVersion = '1.87.0'


### PR DESCRIPTION
Before this PR, when releasing shard processing sessions, we cleaned up all the sessions regardless of whether or not a session is active (has a processing node) or not. Now, we only release the active sessions.

See the [same change](https://github.com/SpineEventEngine/core-java/pull/1157) in `core-java`.