### PR TITLE
Transactional writes for shard sessions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,9 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="100" />
+    <DartCodeStyleSettings>
+      <option name="DELEGATE_TO_DARTFMT" value="false" />
+    </DartCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="PREFER_LONGER_NAMES" value="false" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
@@ -25,6 +28,19 @@
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
+    <codeStyleSettings language="Dart">
+      <option name="RIGHT_MARGIN" value="100" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="true" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="WRAP_ON_TYPING" value="0" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />

--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -7,6 +7,7 @@
       <w>bytebuffer</w>
       <w>closeables</w>
       <w>cqrs</w>
+      <w>dartdocs</w>
       <w>dataset</w>
       <w>datastore</w>
       <w>datastores</w>

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsMessageStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsMessageStorage.java
@@ -145,23 +145,24 @@ public abstract class DsMessageStorage<I, M extends Message, R extends ReadReque
      * and committed. In case there is already an active transaction, the write operation
      * is performed in its scope.
      *
-     * @param message the message to write
+     * @param message
+     *         the message to write
      */
     @SuppressWarnings("OverlyBroadCatchBlock")  // handling all possible transaction-related issues.
     final void writeTransactionally(M message) {
         checkNotNull(message);
 
         boolean txRequired = !datastore.isTransactionActive();
-        if(txRequired) {
+        if (txRequired) {
             datastore.startTransaction();
         }
         try {
             write(message);
-            if(txRequired) {
+            if (txRequired) {
                 datastore.commitTransaction();
             }
         } catch (Exception e) {
-            if(txRequired && datastore.isTransactionActive()) {
+            if (txRequired && datastore.isTransactionActive()) {
                 datastore.rollbackTransaction();
             }
             throw newIllegalStateException("Error committing the transaction.", e);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsShardedWorkRegistry.java
@@ -43,9 +43,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>It is recommended to use this implementation with Cloud Firestore in Datastore mode,
  * as it provides the strong consistency for queries.
  */
-public class DsShardedWorkRegistry
-        extends AbstractWorkRegistry
-        implements Logging {
+public class DsShardedWorkRegistry extends AbstractWorkRegistry implements Logging {
 
     private final DsSessionStorage storage;
 
@@ -98,7 +96,7 @@ public class DsShardedWorkRegistry
 
     @Override
     protected void write(ShardSessionRecord session) {
-        storage().write(session);
+        storage().writeTransactionally(session);
     }
 
     @Override

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.1.0`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.1.1-SNAPSHOT+1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -29,7 +29,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.73.0
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.74.0
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.16.0
@@ -58,7 +58,7 @@
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.90.0
+1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.91.0
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -273,7 +273,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.73.0
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.74.0
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.16.0
@@ -305,7 +305,7 @@
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.90.0
+1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.91.0
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -759,12 +759,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 10 16:15:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 18:13:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.1.0`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.1.1-SNAPSHOT+1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
@@ -1524,4 +1524,4 @@ This report was generated on **Tue Sep 10 16:15:56 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 10 16:15:58 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 18:13:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.1.0</version>
+<version>1.1.1-SNAPSHOT+1</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -28,7 +28,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-datastore</artifactId>
-    <version>1.90.0</version>
+    <version>1.91.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/version.gradle
+++ b/version.gradle
@@ -28,7 +28,7 @@
 def final SPINE_VERSION = '1.1.0'
 
 ext {
-    versionToPublish = SPINE_VERSION
+    versionToPublish = '1.1.1-SNAPSHOT+1'
     
     spineBaseVersion = SPINE_VERSION
     spineCoreVersion = SPINE_VERSION

--- a/version.gradle
+++ b/version.gradle
@@ -33,5 +33,5 @@ ext {
     spineBaseVersion = SPINE_VERSION
     spineCoreVersion = SPINE_VERSION
 
-    datastoreVersion = '1.90.0'
+    datastoreVersion = '1.91.0'
 }


### PR DESCRIPTION
This changeset modifies the write operations of `ShardedSessionRecord`s, so that each record is written in scope of a Datastore transaction.

The version of Datastore client library is bumped to `1.91.0`.

Own version of `gcloud-java` library is set to `1.1.1-SNAPSHOT+1`.