### PR TITLE
Thread-safe transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,6 @@ gcs-auth-key.json
 # They are stored in the encrypted file and are decrypted on the CI server only.
 
 # This file extracted form credentials.tar
-spine-dev*.json
-/datastore/src/test/resources/spine-dev.json
-/stackdriver-trace/src/test/resources/spine-dev.json
+**/spine-dev*.json
 
 package-lock.json

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -432,7 +432,13 @@ public class DatastoreWrapper implements Logging {
         }
     }
 
-    public TransactionWrapper newTransaction() {
+    /**
+     * Starts a new database transaction.
+     *
+     * @return the new transaction
+     * @see TransactionWrapper
+     */
+    public final TransactionWrapper newTransaction() {
         Transaction tx = datastore.newTransaction();
         return new TransactionWrapper(tx);
     }
@@ -448,7 +454,9 @@ public class DatastoreWrapper implements Logging {
      *         if a transaction is already started on this instance of
      *         {@code DatastoreWrapper}
      * @see #isTransactionActive()
+     * @deprecated Use {@link #newTransaction()} instead.
      */
+    @Deprecated
     public void startTransaction() throws IllegalStateException {
         checkState(!isTransactionActive(), NOT_ACTIVE_TRANSACTION_CONDITION_MESSAGE);
         activeTransaction = datastore.newTransaction();
@@ -466,7 +474,9 @@ public class DatastoreWrapper implements Logging {
      *         if no transaction is started on this instance of
      *         {@code DatastoreWrapper}
      * @see #isTransactionActive()
+     * @deprecated Use {@link #newTransaction()} instead.
      */
+    @Deprecated
     public void commitTransaction() throws IllegalStateException {
         checkState(isTransactionActive(), ACTIVE_TRANSACTION_CONDITION_MESSAGE);
         activeTransaction.commit();
@@ -486,7 +496,9 @@ public class DatastoreWrapper implements Logging {
      *         if no transaction is active for the current
      *         instance of {@code DatastoreWrapper}
      * @see #isTransactionActive()
+     * @deprecated Use {@link #newTransaction()} instead.
      */
+    @Deprecated
     public void rollbackTransaction() throws IllegalStateException {
         checkState(isTransactionActive(), ACTIVE_TRANSACTION_CONDITION_MESSAGE);
         activeTransaction.rollback();
@@ -497,7 +509,9 @@ public class DatastoreWrapper implements Logging {
      * Checks whether there is an active transaction on this instance of {@code DatastoreWrapper}.
      *
      * @return {@code true} if there is an active transaction, {@code false} otherwise
+     * @deprecated Use {@link #newTransaction()} instead.
      */
+    @Deprecated
     public boolean isTransactionActive() {
         return activeTransaction != null && activeTransaction.isActive();
     }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -432,6 +432,11 @@ public class DatastoreWrapper implements Logging {
         }
     }
 
+    public TransactionWrapper newTransaction() {
+        Transaction tx = datastore.newTransaction();
+        return new TransactionWrapper(tx);
+    }
+
     /**
      * Starts a transaction.
      *

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsMessageStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsMessageStorage.java
@@ -141,31 +141,20 @@ public abstract class DsMessageStorage<I, M extends Message, R extends ReadReque
      * Behaves similarly to {@link #write(Message)}, but performs the operation
      * in scope of a Datastore transaction.
      *
-     * <p>If there is no active transaction at the moment, the new transaction is started
-     * and committed. In case there is already an active transaction, the write operation
-     * is performed in its scope.
-     *
      * @param message
      *         the message to write
      */
-    @SuppressWarnings("OverlyBroadCatchBlock")  // handling all possible transaction-related issues.
     final void writeTransactionally(M message) {
         checkNotNull(message);
 
-        boolean txRequired = !datastore.isTransactionActive();
-        if (txRequired) {
-            datastore.startTransaction();
-        }
-        try {
-            write(message);
-            if (txRequired) {
-                datastore.commitTransaction();
-            }
-        } catch (Exception e) {
-            if (txRequired && datastore.isTransactionActive()) {
-                datastore.rollbackTransaction();
-            }
-            throw newIllegalStateException("Error committing the transaction.", e);
+        try (TransactionWrapper tx = datastore.newTransaction()) {
+            Entity entity = toEntity(message);
+            tx.createOrUpdate(entity);
+            tx.commit();
+        } catch (RuntimeException e) {
+            throw newIllegalStateException(e,
+                                           "Error writing a `%s` in transaction.",
+                                           message.getClass().getName());
         }
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/MessageColumn.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/MessageColumn.java
@@ -22,6 +22,7 @@ package io.spine.server.storage.datastore;
 
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Value;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 
@@ -55,6 +56,7 @@ interface MessageColumn<M extends Message> {
      *         the message which field value is going to be set
      * @return the same instance of {@code builder} with the property filled
      */
+    @CanIgnoreReturnValue
     default Entity.Builder fill(Entity.Builder builder, M message) {
         Value<?> value = getter().apply(message);
         builder.set(columnName(), value);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/RecordStorageBuilder.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/RecordStorageBuilder.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.datastore;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.Descriptor;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.model.EntityClass;
@@ -58,6 +59,7 @@ abstract class RecordStorageBuilder<I,
     /**
      * Sets the type URL of the entity state, which is stored in the resulting storage.
      */
+    @CanIgnoreReturnValue
     public B setStateType(TypeUrl stateTypeUrl) {
         checkNotNull(stateTypeUrl);
         Descriptor descriptor = stateTypeUrl.toTypeName()
@@ -69,6 +71,7 @@ abstract class RecordStorageBuilder<I,
     /**
      * Assignts the ID class of the stored entities.
      */
+    @CanIgnoreReturnValue
     public B setIdClass(Class<I> idClass) {
         this.idClass = checkNotNull(idClass);
         return self();
@@ -77,6 +80,7 @@ abstract class RecordStorageBuilder<I,
     /**
      * Assigns the class of the stored entity.
      */
+    @CanIgnoreReturnValue
     public B setEntityClass(Class<? extends Entity<?, ?>> entityClass) {
         this.entityClass = checkNotNull(entityClass);
         return self();
@@ -90,6 +94,7 @@ abstract class RecordStorageBuilder<I,
      * {@linkplain #setEntityClass(Class) entity class} separately.
      */
     @SuppressWarnings("unchecked") // The ID class is ensured by the parameter type.
+    @CanIgnoreReturnValue
     public B setModelClass(EntityClass<? extends Entity<I, ?>> modelClass) {
         TypeUrl stateType = modelClass.stateType();
         Class<I> idClass = (Class<I>) modelClass.idClass();
@@ -104,6 +109,7 @@ abstract class RecordStorageBuilder<I,
     /**
      * Sets the {@link io.spine.server.storage.datastore.DatastoreWrapper} to use in this storage.
      */
+    @CanIgnoreReturnValue
     public B setDatastore(DatastoreWrapper datastore) {
         this.datastore = checkNotNull(datastore);
         return self();
@@ -117,6 +123,7 @@ abstract class RecordStorageBuilder<I,
      *         {@link io.spine.server.storage.Storage#isMultitenant multitenant},
      *         {@code false} otherwise
      */
+    @CanIgnoreReturnValue
     public B setMultitenant(boolean multitenant) {
         this.multitenant = multitenant;
         return self();
@@ -126,6 +133,7 @@ abstract class RecordStorageBuilder<I,
      * Assigns the type registry of
      * the {@linkplain io.spine.server.entity.storage.EntityColumn entity columns}.
      */
+    @CanIgnoreReturnValue
     public B setColumnTypeRegistry(
             ColumnTypeRegistry<? extends DatastoreColumnType<?, ?>> columnTypeRegistry) {
         this.columnTypeRegistry = checkNotNull(columnTypeRegistry);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.datastore;
 
+import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Transaction;
@@ -28,6 +29,9 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * A Cloud Datastore transaction wrapper.
+ */
 public final class TransactionWrapper implements AutoCloseable {
 
     private final Transaction tx;
@@ -36,23 +40,45 @@ public final class TransactionWrapper implements AutoCloseable {
         this.tx = checkNotNull(tx);
     }
 
+    /**
+     * Puts the given entity into the Datastore in the transaction.
+     */
     public void createOrUpdate(Entity entity) {
         tx.put(entity);
     }
 
+    /**
+     * Reads an entity from the Datastore in the transaction.
+     *
+     * @return the entity with the given key or {@code Optional.empty()} if such an entity does not
+     *         exist
+     */
     public Optional<Entity> read(Key key) {
         Entity entity = tx.get(key);
         return Optional.ofNullable(entity);
     }
 
+    /**
+     * Commits this transaction.
+     *
+     * @throws DatastoreException if the transaction is no longer active
+     */
     public void commit() {
         tx.commit();
     }
 
+    /**
+     * Rolls back this transaction.
+     *
+     * @throws DatastoreException if the transaction is no longer active
+     */
     public void rollback() {
         tx.rollback();
     }
 
+    /**
+     * Rolls back this transaction if it's still active.
+     */
     @Override
     public void close() {
         if (tx.isActive()) {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.Transaction;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class TransactionWrapper implements AutoCloseable {
+
+    private final Transaction tx;
+
+    TransactionWrapper(Transaction tx) {
+        this.tx = checkNotNull(tx);
+    }
+
+    public void createOrUpdate(Entity entity) {
+        tx.put(entity);
+    }
+
+    public Optional<Entity> read(Key key) {
+        Entity entity = tx.get(key);
+        return Optional.ofNullable(entity);
+    }
+
+    public void commit() {
+        tx.commit();
+    }
+
+    public void rollback() {
+        tx.rollback();
+    }
+
+    @Override
+    public void close() {
+        if (tx.isActive()) {
+            rollback();
+        }
+    }
+}

--- a/datastore/src/main/java/io/spine/server/storage/datastore/package-info.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/package-info.java
@@ -17,12 +17,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 /**
  * This package contains Google Cloud Datastore implementation of the storages.
  *
  * @see io.spine.server.storage.AbstractStorage
  */
+@CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.datastore;
+
+import com.google.errorprone.annotations.CheckReturnValue;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
@@ -77,6 +77,7 @@ class DatastoreWrapperTest {
         wrapper.dropTable(NAMESPACE_HOLDER_KIND);
     }
 
+    @SuppressWarnings("deprecation") // To be deleted alongside with the tested API.
     @Nested
     class SingleTenant {
 

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.protobuf.Empty;
+import io.spine.testing.server.storage.datastore.TestDatastoreWrapper;
+import io.spine.type.TypeUrl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.storage.datastore.given.DatastoreWrapperTestEnv.localDatastore;
+import static io.spine.server.storage.datastore.tenant.TestNamespaceSuppliers.singleTenant;
+
+@DisplayName("`TransactionWrapper` should")
+class TransactionWrapperTest {
+
+    private TestDatastoreWrapper datastore;
+    private KeyFactory keyFactory;
+
+    @BeforeEach
+    void setUp() {
+        datastore = TestDatastoreWrapper.wrap(localDatastore(), false);
+        keyFactory = datastore.keyFactory(Kind.of(TypeUrl.of(Empty.class).value()));
+    }
+
+    @AfterEach
+    void cleanUpDatastore() {
+        datastore.dropAllTables();
+    }
+
+    @Test
+    @DisplayName("write transactionally")
+    void write() {
+        Key key = keyFactory.newKey(newUuid());
+        Entity entity = Entity.newBuilder(key)
+                              .set("field", 42)
+                              .build();
+        TransactionWrapper tx = datastore.newTransaction();
+        tx.createOrUpdate(entity);
+        tx.commit();
+        Entity readEntity = datastore.read(key);
+        assertThat(readEntity)
+                .isEqualTo(entity);
+    }
+
+    @Test
+    @DisplayName("read transactionally")
+    void read() {
+        Key key = keyFactory.newKey(newUuid());
+        Entity entity = Entity.newBuilder(key)
+                              .set("field_name", newUuid())
+                              .build();
+        datastore.create(entity);
+        TransactionWrapper tx = datastore.newTransaction();
+        Optional<Entity> read = tx.read(key);
+        tx.commit();
+        Entity readEntity = read.orElseGet(Assertions::fail);
+        assertThat(readEntity)
+                .isEqualTo(entity);
+    }
+
+    @Test
+    @DisplayName("read and write transactionally")
+    void readWrite() {
+        Key key = keyFactory.newKey(newUuid());
+        String field = "number";
+        Entity original = Entity.newBuilder(key)
+                                .set(field, 1)
+                                .build();
+        datastore.create(original);
+        TransactionWrapper tx = datastore.newTransaction();
+        Entity updated = Entity.newBuilder(original)
+                               .set(field, 2)
+                               .build();
+        assertThat(tx.read(key)
+                     .orElseGet(Assertions::fail)
+                     .getLong(field))
+                .isEqualTo(original.getLong(field));
+
+        tx.createOrUpdate(updated);
+
+        assertThat(tx.read(key)
+                     .orElseGet(Assertions::fail)
+                     .getLong(field))
+                .isEqualTo(original.getLong(field));
+
+        tx.commit();
+
+        Entity finalEntity = datastore.read(key);
+        assertThat(finalEntity)
+                .isNotNull();
+        assertThat(finalEntity.getLong(field))
+                .isEqualTo(updated.getLong(field));
+    }
+
+    @Test
+    @DisplayName("rollback changes")
+    void rollback() {
+        Key key = keyFactory.newKey(newUuid());
+        Entity entity = Entity.newBuilder(key)
+                              .set("example", newUuid())
+                              .build();
+        TransactionWrapper tx = datastore.newTransaction();
+        tx.createOrUpdate(entity);
+        tx.rollback();
+        Entity readEntity = datastore.read(key);
+        assertThat(readEntity)
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("rollback on close")
+    void closeAndRollback() {
+        Key key = keyFactory.newKey(newUuid());
+        try (TransactionWrapper tx = datastore.newTransaction()) {
+            Entity entity = Entity.newBuilder(key)
+                                  .set("test", newUuid())
+                                  .build();
+            tx.createOrUpdate(entity);
+        }
+        Entity readEntity = datastore.read(key);
+        assertThat(readEntity)
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("not rollback if already committed")
+    void notRollbackIfNotActive() {
+        Key key = keyFactory.newKey(newUuid());
+        try (TransactionWrapper tx = datastore.newTransaction()) {
+            Entity entity = Entity.newBuilder(key)
+                                  .set("test1", newUuid())
+                                  .build();
+            tx.createOrUpdate(entity);
+            tx.commit();
+        }
+        Entity readEntity = datastore.read(key);
+        assertThat(readEntity)
+                .isNotNull();
+    }
+}

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.1.3-SNAPSHOT+1`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.1.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -29,7 +29,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.74.0
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.79.0
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.16.0
@@ -58,7 +58,7 @@
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.91.0
+1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.96.0
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -152,15 +152,15 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -273,7 +273,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.74.0
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.79.0
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.16.0
@@ -305,7 +305,7 @@
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.91.0
+1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.96.0
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -472,15 +472,15 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -734,12 +734,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 02 16:28:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 16:00:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.1.3-SNAPSHOT+1`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.1.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
@@ -1474,12 +1474,12 @@ This report was generated on **Wed Oct 02 16:28:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 16:00:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.1.3-SNAPSHOT+1`
+# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.1.4`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -1508,7 +1508,7 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.74.0
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.79.0
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.16.0
@@ -1537,7 +1537,7 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.91.0
+1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.96.0
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1631,15 +1631,15 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -1773,7 +1773,7 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.74.0
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-datastore-v1 **Version:** 0.79.0
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.16.0
@@ -1805,7 +1805,7 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.91.0
+1. **Group:** com.google.cloud **Name:** google-cloud-datastore **Version:** 1.96.0
      * **POM Project URL:** [https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1972,15 +1972,15 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.23.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.24.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -2234,4 +2234,4 @@ This report was generated on **Wed Oct 02 16:28:25 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 02 16:28:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 16:00:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.1.3-SNAPSHOT+1</version>
+<version>1.1.4</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -28,7 +28,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-datastore</artifactId>
-    <version>1.91.0</version>
+    <version>1.96.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -40,7 +40,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -58,7 +58,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -114,12 +114,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.1.3-SNAPSHOT+1</version>
+    <version>1.1.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.1.3-SNAPSHOT+1</version>
+    <version>1.1.4</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle
+++ b/version.gradle
@@ -25,13 +25,13 @@
  * {@code .config/gradle/dependencies.gradle}.
  */
 
-def final SPINE_VERSION = '1.1.3-SNAPSHOT+1'
+def final SPINE_VERSION = '1.1.4'
 
 ext {
     versionToPublish = SPINE_VERSION
     
     spineBaseVersion = SPINE_VERSION
-    spineCoreVersion = '1.1.2'
+    spineCoreVersion = SPINE_VERSION
 
     datastoreVersion = '1.91.0'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -33,5 +33,5 @@ ext {
     spineBaseVersion = SPINE_VERSION
     spineCoreVersion = SPINE_VERSION
 
-    datastoreVersion = '1.91.0'
+    datastoreVersion = '1.96.0'
 }


### PR DESCRIPTION
In this PR we introduce an API for thread-safe Datastore transactions.

Previously, transactions were handled by `DatastoreWrapper`. When required, the wrapper substituted the `Datastore` for a transaction and executed all the requests upon that transaction.
This approach caused concurrency issues.
Now that API is deprecated. It should be removed in subsequent releases.

The new API for transactions allows managing a single Datastore transaction independently of all the others.