### PR TITLE
Update to Spine Core `1.2.5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ dependencies {
     implementation (
     
         // Datastore Storage support library.
-        "io.spine.gcloud:spine-datastore:1.2.0",
+        "io.spine.gcloud:spine-datastore:1.2.5",
         
         // Stackdriver Trace support library.
-        "io.spine.gcloud:spine-stackdriver-trace:1.2.0",
+        "io.spine.gcloud:spine-stackdriver-trace:1.2.5",
 
         // Datastore-related test utilities (if needed).
-        "io.spine.gcloud:testutil-gcloud:1.2.0"
+        "io.spine.gcloud:testutil-gcloud:1.2.5"
     )
 }
 ```

--- a/datastore/config/index.yaml
+++ b/datastore/config/index.yaml
@@ -14,6 +14,7 @@ indexes:
     properties:
       - name: inbox_shard
       - name: when_received
+      - name: version
 
   # Indexes for the Aggregates.
   #

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsMessageStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsMessageStorage.java
@@ -188,13 +188,30 @@ public abstract class DsMessageStorage<I, M extends Message, R extends ReadReque
      * @see DatastoreWrapper#readAll(StructuredQuery, int)
      */
     Iterator<M> readAll(EntityQuery.Builder queryBuilder, int readBatchSize) {
-        StructuredQuery<Entity> query =
-                queryBuilder.setKind(kind.value())
-                            .build();
+        StructuredQuery<Entity> query = queryBuilder.setKind(kind.value())
+                                                    .build();
         Iterator<Entity> iterator = datastore.readAll(query, readBatchSize);
-        Iterator<M> transformed =
-                Iterators.transform(iterator, (e) -> Entities.toMessage(e, typeUrl));
+        Iterator<M> transformed = Iterators.transform(iterator,
+                                                      (e) -> Entities.toMessage(e, typeUrl));
         return transformed;
+    }
+
+    /**
+     * Reads the messages from the storage.
+     *
+     * <p>The caller is responsible for setting the query limits and interpreting the results.
+     * This call does not trigger reading of the entire dataset page-by-page.
+     *
+     * @param queryBuilder the partially composed query builder
+     * @see DatastoreWrapper#read(StructuredQuery)
+     * @see #readAll(EntityQuery.Builder, int)
+     */
+    Iterator<M> read(EntityQuery.Builder queryBuilder) {
+        StructuredQuery<Entity> query = queryBuilder.setKind(kind.value())
+                                                    .build();
+        DsQueryIterator<Entity> iterator = datastore.read(query);
+        Iterator<M> result = Iterators.transform(iterator, (e) -> Entities.toMessage(e, typeUrl));
+        return result;
     }
 
     /**

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsDeliverySmokeTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsDeliverySmokeTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import io.spine.server.ServerEnvironment;
+import io.spine.server.delivery.DeliveryTest;
+import io.spine.testing.SlowTest;
+import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Smoke tests on {@link Delivery} functionality running on top of Datastore-backed storage.
+ *
+ * <p>The tests are extremely slow, so only a tiny portion of the original {@link DeliveryTest}
+ * is launched.
+ */
+@DisplayName("Datastore-backed `Delivery` should ")
+@SlowTest
+public class DsDeliverySmokeTest extends DeliveryTest {
+
+    private TestDatastoreStorageFactory factory;
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        super.setUp();
+        factory = TestDatastoreStorageFactory.local();
+        ServerEnvironment.instance()
+                         .configureStorageForTests(factory);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        if (factory != null) {
+            factory.tearDown();
+        }
+    }
+
+    @Test
+    @DisplayName("deliver messages via multiple shards to multiple targets in a multi-threaded env")
+    @Override
+    public void manyTargets_manyShards_manyThreads() {
+        super.manyTargets_manyShards_manyThreads();
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void markDelivered() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_singleShard_manyThreads() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void manyTargets_singleShard_manyThreads() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_manyShards_manyThreads() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_manyShards_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_singleShard_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void manyTargets_singleShard_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void manyTargets_manyShards_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void withCustomStrategy() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void calculateStats() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void returnOptionalEmptyIfPicked() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void notifyDeliveryMonitorOfDeliveryCompletion() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void deliverInBatch() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void deliverMessagesInOrderOfEmission() {
+    }
+}

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
@@ -57,8 +57,7 @@ import static org.junit.Assert.assertTrue;
 @DisplayName("`DsInboxStorage` should")
 class DsInboxStorageTest extends InboxStorageTest {
 
-    private final TestDatastoreStorageFactory factory =
-            TestDatastoreStorageFactory.local();
+    private final TestDatastoreStorageFactory factory = TestDatastoreStorageFactory.local();
 
     @Override
     @BeforeEach

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.2.1`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.2.5`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -689,12 +689,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 19:27:23 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 19 17:37:41 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.2.1`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.2.5`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
@@ -1380,12 +1380,12 @@ This report was generated on **Mon Nov 11 19:27:23 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 19:27:24 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 19 17:37:46 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.2.1`
+# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.2.5`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -2095,4 +2095,4 @@ This report was generated on **Mon Nov 11 19:27:24 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 19:27:26 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 19 17:37:47 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.2.1</version>
+<version>1.2.5</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,7 +40,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -58,7 +58,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.5</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -114,12 +114,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/stackdriver-trace/src/main/java/io/spine/server/trace/stackdriver/SignalSpan.java
+++ b/stackdriver-trace/src/main/java/io/spine/server/trace/stackdriver/SignalSpan.java
@@ -100,7 +100,7 @@ public class SignalSpan {
     }
 
     private String displayName() {
-        TypeName signalType = signal.typeUrl()
+        TypeName signalType = signal.enclosedTypeUrl()
                                     .toTypeName();
         ClassName className = ClassName.of(receiverType.getJavaClassName());
         return format("%s handles %s", className.toSimple(), signalType.simpleName());

--- a/stackdriver-trace/src/main/java/io/spine/server/trace/stackdriver/SpanAttribute.java
+++ b/stackdriver-trace/src/main/java/io/spine/server/trace/stackdriver/SpanAttribute.java
@@ -76,7 +76,7 @@ enum SpanAttribute {
         @Override
         AttributeValue value(SignalSpan signalSpan) {
             String signalType = signalSpan.signal()
-                                          .typeUrl()
+                                          .enclosedTypeUrl()
                                           .value();
             return SpanAttribute.stringValue(signalType);
         }

--- a/version.gradle
+++ b/version.gradle
@@ -25,12 +25,12 @@
  * {@code .config/gradle/dependencies.gradle}.
  */
 
-def final SPINE_VERSION = '1.2.1'
+def final SPINE_VERSION = '1.2.5'
 
 ext {
     versionToPublish = SPINE_VERSION
     
-    spineBaseVersion = SPINE_VERSION
+    spineBaseVersion = '1.2.3'
     spineCoreVersion = SPINE_VERSION
 
     datastoreVersion = '1.100.0'


### PR DESCRIPTION
This changeset updates the API to the Spine Core in version `1.2.5`.

**Notable changes**

* A column for `InboxMessage.version` has been added.
* Datastore-backed `Delivery` test is now added; it serves a smoke-test check.

The library version is set to `1.2.5`.