### PR TITLE
Add example of correct Inbox Datastore indexes

### DIFF
--- a/datastore/config/index.yaml
+++ b/datastore/config/index.yaml
@@ -10,11 +10,22 @@ indexes:
     - name: type
     - name: created
 
+  # Index required for `DsInboxStorage.readAll` query.
+
   - kind: spine.server.delivery.InboxMessage
     properties:
       - name: inbox_shard
+      - name: of_total_inbox_shards
       - name: when_received
       - name: version
+
+  # Index required for `DsInboxStorage.oldestMessageToDeliver` query.
+
+  - kind: spine.server.delivery.InboxMessage
+    properties:
+      - name: inbox_shard
+      - name: of_total_inbox_shards
+      - name: status
 
   # Indexes for the Aggregates.
   #


### PR DESCRIPTION
In this PR I have added real-world examples of the Datastore indexes required for the `DsInboxStorage`.