### PR TITLE
Expose transaction API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,7 @@ subprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'io.spine.tools.spine-model-compiler'
     apply from: deps.scripts.modelCompiler
+    apply from: deps.scripts.slowTests
 
     sourceSets {
         main {

--- a/datastore/build.gradle
+++ b/datastore/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 }
 
 task startDatastore(type: com.github.psxpaul.task.ExecFork) {
-    description = "Starts local in-memory datastore using scripts from ./scripts folder."
+    description = "Starts local in-memory datastore."
     group = "Build Setup"
 
     executable = "$rootDir/scripts/start-datastore.${runsOnWindows ? 'bat' : 'sh'}"

--- a/datastore/build.gradle
+++ b/datastore/build.gradle
@@ -56,5 +56,5 @@ task startDatastore(type: com.github.psxpaul.task.ExecFork) {
     killDescendants = false
 }
 
-test.dependsOn startDatastore
+tasks.withType(Test) { it.dependsOn startDatastore }
 startDatastore.shouldRunAfter assemble

--- a/datastore/build.gradle
+++ b/datastore/build.gradle
@@ -49,6 +49,9 @@ task startDatastore(type: com.github.psxpaul.task.ExecFork) {
     //
     waitForPort = 8081
 
+    standardOutput = "$buildDir/ds-emulator/stdout.log"
+    errorOutput = "$buildDir/ds-emulator/stderr.log"
+
     // Suppress a console warning for JRE < 9
     killDescendants = false
 }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -273,15 +273,7 @@ public class DatastoreWrapper implements Logging {
      * @see DatastoreReader#run(Query)
      */
     public <R> DsQueryIterator<R> read(StructuredQuery<R> query) {
-        Namespace namespace = namespaceSupplier.get();
-        StructuredQuery<R> queryWithNamespace =
-                query.toBuilder()
-                     .setNamespace(namespace.getValue())
-                     .build();
-        _trace().log("Reading entities of `%s` kind in `%s` namespace.",
-                     query.getKind(), namespace.getValue());
-        DsQueryIterator<R> result = new DsQueryIterator<>(queryWithNamespace, actor);
-        return result;
+        return DsQueryIterator.compose(actor, query, namespaceSupplier);
     }
 
     /**
@@ -443,7 +435,7 @@ public class DatastoreWrapper implements Logging {
      */
     public final TransactionWrapper newTransaction() {
         Transaction tx = datastore.newTransaction();
-        return new TransactionWrapper(tx);
+        return new TransactionWrapper(tx, namespaceSupplier);
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -131,7 +131,7 @@ public class DatastoreWrapper implements Logging {
      *         new {@link Entity} to put into the Datastore
      * @throws DatastoreException
      *         upon failure
-     * @see DatastoreWriter#put(FullEntity)
+     * @see DatastoreWriter#add(FullEntity)
      */
     public void create(Entity entity) throws DatastoreException {
         actor.add(entity);

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -210,9 +210,6 @@ public class DatastoreWrapper implements Logging {
     /**
      * Retrieves an {@link Entity} for each of the given keys.
      *
-     * <p>A call to {@link Iterator#remove() Iterator.remove()} causes
-     * an {@link UnsupportedOperationException}.
-     *
      * <p>The results are returned in an order matching that of the provided keys
      * with {@code null}s in place of missing and inactive entities.
      *

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -349,12 +349,12 @@ public class DatastoreWrapper implements Logging {
      *         kind (a.k.a. type, table, etc.) of the records to delete
      */
     @VisibleForTesting
-    protected void dropTable(String table) {
+    protected void dropTable(Kind table) {
         Namespace namespace = namespaceSupplier.get();
         StructuredQuery<Entity> query =
                 Query.newEntityQueryBuilder()
                      .setNamespace(namespace.value())
-                     .setKind(table)
+                     .setKind(table.value())
                      .build();
         _trace().log("Deleting all entities of `%s` kind in `%s` namespace.",
                      table, namespace.value());
@@ -415,6 +415,7 @@ public class DatastoreWrapper implements Logging {
      * @return an instance of {@link KeyFactory} for given kind
      */
     public KeyFactory keyFactory(Kind kind) {
+        checkNotNull(kind);
         DatastoreKind datastoreKind = new DatastoreKind(projectId(), kind);
         KeyFactory keyFactory = keyFactories.get(datastoreKind);
         if (keyFactory == null) {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -241,7 +241,7 @@ public class DatastoreWrapper implements Logging {
      * @see DatastoreReader#run(Query)
      */
     public <R> DsQueryIterator<R> read(StructuredQuery<R> query) {
-        return DsQueryIterator.compose(datastore, query, namespaceSupplier);
+        return DsQueryIterator.compose(datastore, query, namespaceSupplier.get());
     }
 
     /**
@@ -353,11 +353,11 @@ public class DatastoreWrapper implements Logging {
         Namespace namespace = namespaceSupplier.get();
         StructuredQuery<Entity> query =
                 Query.newEntityQueryBuilder()
-                     .setNamespace(namespace.getValue())
+                     .setNamespace(namespace.value())
                      .setKind(table)
                      .build();
         _trace().log("Deleting all entities of `%s` kind in `%s` namespace.",
-                     table, namespace.getValue());
+                     table, namespace.value());
         Iterator<Entity> queryResult = read(query);
         List<Entity> entities = newArrayList(queryResult);
         deleteEntities(entities);
@@ -422,8 +422,8 @@ public class DatastoreWrapper implements Logging {
         }
         Namespace namespace = namespaceSupplier.get();
         _trace().log("Retrieving KeyFactory for kind `%s` in `%s` namespace.",
-                     kind, namespace.getValue());
-        keyFactory.setNamespace(namespace.getValue());
+                     kind, namespace.value());
+        keyFactory.setNamespace(namespace.value());
         return keyFactory;
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DatastoreWrapper.java
@@ -304,7 +304,6 @@ public class DatastoreWrapper implements Logging {
      *         if the provided {@linkplain StructuredQuery#getLimit() query includes a limit} or
      *         the provided {@code batchSize} is 0
      */
-    @SuppressWarnings("unchecked") // Checked logically.
     private <R> Iterator<R>
     readAllPageByPage(StructuredQuery<R> query, @Nullable Integer pageSize) {
         checkArgument(query.getLimit() == null,

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
@@ -41,6 +41,7 @@ import static com.google.cloud.datastore.StructuredQuery.CompositeFilter.and;
 import static com.google.cloud.datastore.StructuredQuery.OrderBy.asc;
 import static com.google.cloud.datastore.StructuredQuery.PropertyFilter.eq;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.protobuf.util.Timestamps.toNanos;
 import static io.spine.server.delivery.InboxMessageStatus.TO_DELIVER;
 
 /**
@@ -49,8 +50,6 @@ import static io.spine.server.delivery.InboxMessageStatus.TO_DELIVER;
 public class DsInboxStorage
         extends DsMessageStorage<InboxMessageId, InboxMessage, InboxReadRequest>
         implements InboxStorage {
-
-    private static final int NANOS_PER_SECOND = 1_000_000;
 
     protected DsInboxStorage(DatastoreWrapper datastore, boolean multitenant) {
         super(datastore, multitenant);
@@ -150,8 +149,7 @@ public class DsInboxStorage
 
         receivedAt("received_at", (m) -> {
             Timestamp timestamp = m.getWhenReceived();
-            long epochNanos = timestamp.getSeconds() * NANOS_PER_SECOND + timestamp.getNanos();
-            return LongValue.of(epochNanos);
+            return LongValue.of(toNanos(timestamp));
         }),
 
         version("version", (m) -> {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
@@ -25,7 +25,6 @@ import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.LongValue;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StringValue;
-import com.google.cloud.datastore.TimestampValue;
 import com.google.protobuf.Timestamp;
 import io.spine.server.delivery.InboxMessage;
 import io.spine.server.delivery.InboxMessageId;
@@ -38,7 +37,6 @@ import io.spine.string.Stringifiers;
 import java.util.Iterator;
 import java.util.Optional;
 
-import static com.google.cloud.Timestamp.fromProto;
 import static com.google.cloud.datastore.StructuredQuery.CompositeFilter.and;
 import static com.google.cloud.datastore.StructuredQuery.OrderBy.asc;
 import static com.google.cloud.datastore.StructuredQuery.PropertyFilter.eq;
@@ -148,14 +146,6 @@ public class DsInboxStorage
         status("status", (m) -> {
             return StringValue.of(m.getStatus()
                                    .toString());
-        }),
-
-        /**
-         * @deprecated Use {@link #receivedAt} instead.
-         */
-        @Deprecated
-        whenReceived("when_received", (m) -> {
-            return TimestampValue.of(fromProto(m.getWhenReceived()));
         }),
 
         receivedAt("received_at", (m) -> {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsInboxStorage.java
@@ -70,9 +70,9 @@ public class DsInboxStorage
     public Page<InboxMessage> readAll(ShardIndex index, int pageSize) {
         checkNotNull(index);
 
-        EntityQuery.Builder builder = queryInShard(index);
-        builder.setOrderBy(asc(Column.receivedAt.columnName()),
-                           asc(Column.version.columnName()));
+        EntityQuery.Builder builder = queryInShard(index)
+                .setOrderBy(asc(Column.receivedAt.columnName()),
+                            asc(Column.version.columnName()));
         Iterator<InboxMessage> iterator = readAll(builder, pageSize);
         return new InboxPage(iterator, pageSize);
     }

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsLookupByIds.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsLookupByIds.java
@@ -213,8 +213,8 @@ final class DsLookupByIds<I> {
 
     private Stream<@Nullable Entity> read(Iterable<I> ids) {
         Collection<Key> keys = toKeys(ids);
-        Stream<@Nullable Entity> entities = stream(datastore.read(keys));
-        return entities;
+        Collection<@Nullable Entity> entities = datastore.lookup(keys);
+        return entities.stream();
     }
 
     private Collection<Key> toKeys(Iterable<I> ids) {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryIterator.java
@@ -27,7 +27,6 @@ import com.google.cloud.datastore.StructuredQuery;
 import com.google.common.collect.UnmodifiableIterator;
 import io.spine.annotation.Internal;
 import io.spine.logging.Logging;
-import io.spine.server.storage.datastore.tenant.Namespace;
 
 import java.util.NoSuchElementException;
 
@@ -63,44 +62,11 @@ public final class DsQueryIterator<R> extends UnmodifiableIterator<R> implements
 
     private boolean terminated;
 
-    private DsQueryIterator(StructuredQuery<R> query, DatastoreReader datastore) {
+    DsQueryIterator(StructuredQuery<R> query, DatastoreReader datastore) {
         super();
-        this.query = query;
+        this.query = checkNotNull(query);
         this.limit = query.getLimit();
-        this.currentPage = datastore.run(query);
-    }
-
-    /**
-     * Executes the given query in the given {@link DatastoreReader} and wraps the results into
-     * an instance of {@code DsQueryIterator}.
-     *
-     * @param datastore
-     *         the Datastore API accessor
-     * @param query
-     *         the query to execute
-     * @param namespace
-     *         the {@link Namespace} in which the query operates
-     * @param <R>
-     *         the type of the returned result
-     * @return an iterator of Datastore database objects, e.g. entities, keys
-     */
-    static <R> DsQueryIterator<R>
-    compose(DatastoreReader datastore,
-            StructuredQuery<R> query,
-            Namespace namespace) {
-        checkNotNull(datastore);
-        checkNotNull(query);
-        checkNotNull(namespace);
-
-        StructuredQuery<R> queryWithNamespace =
-                query.toBuilder()
-                     .setNamespace(namespace.value())
-                     .build();
-        DsQueryIterator<R> iterator = new DsQueryIterator<>(queryWithNamespace, datastore);
-        iterator._trace()
-                .log("Reading entities of `%s` kind in `%s` namespace.",
-                     query.getKind(), namespace.value());
-        return iterator;
+        this.currentPage = checkNotNull(datastore).run(query);
     }
 
     @Override

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsQueryPageIterator.java
@@ -42,7 +42,7 @@ import java.util.NoSuchElementException;
  * @param <R>
  *         the type of queried objects
  */
-final class DsQueryPageIterator<R> implements Iterator<DsQueryIterator> {
+final class DsQueryPageIterator<R> implements Iterator<DsQueryIterator<R>> {
 
     private final DatastoreWrapper datastore;
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsReaderLookup.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsReaderLookup.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore;
+
+import com.google.cloud.datastore.DatastoreReader;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.StructuredQuery;
+import com.google.common.collect.ImmutableList;
+import io.spine.logging.Logging;
+import io.spine.server.storage.datastore.tenant.Namespace;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.Math.min;
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * A low-level Datastore lookup.
+ *
+ * <p>Uses a given {@link DatastoreReader} to find requested methods.
+ */
+final class DsReaderLookup implements Logging {
+
+    private static final int MAX_KEYS_PER_READ_REQUEST = 1000;
+
+    private final DatastoreReader datastore;
+
+    DsReaderLookup(DatastoreReader datastore) {
+        this.datastore = checkNotNull(datastore);
+    }
+
+    <R> DsQueryIterator<R> execute(StructuredQuery<R> query, Namespace namespace) {
+        checkNotNull(query);
+        checkNotNull(namespace);
+
+        StructuredQuery<R> queryWithNamespace = query.toBuilder()
+                                                     .setNamespace(namespace.value())
+                                                     .build();
+        DsQueryIterator<R> iterator = new DsQueryIterator<>(queryWithNamespace, datastore);
+        iterator._trace()
+                .log("Reading entities of `%s` kind in `%s` namespace.",
+                     query.getKind(), namespace.value());
+        return iterator;
+    }
+
+    /**
+     * Reads multiple records by their IDs.
+     *
+     * <p>The order of the resulting list is the same as the order of the keys. For keys which are
+     * not in the database, {@code null} values are returned.
+     */
+    List<@Nullable Entity> find(Collection<Key> keys) {
+        ImmutableList<Key> keysList = ImmutableList.copyOf(keys);
+        List<Entity> entities = keysList.size() <= MAX_KEYS_PER_READ_REQUEST
+                                ? fetch(keysList)
+                                : readBulk(keysList);
+        return unmodifiableList(entities);
+    }
+
+    /**
+     * Reads big number of records.
+     *
+     * <p>Google App Engine Datastore has a limitation on the amount of entities queried with a
+     * single call — 1000 entities per query. To deal with this limitation we read the entities in
+     * pagination fashion 1000 entity per page.
+     *
+     * @param keys
+     *         {@link Key keys} to find the entities for
+     * @return ordered sequence of {@link Entity entities}
+     */
+    private List<Entity> readBulk(List<Key> keys) {
+        int pageCount = keys.size() / MAX_KEYS_PER_READ_REQUEST + 1;
+        _trace().log("Reading a big bulk of entities synchronously. The data is read as %d pages.",
+                     pageCount);
+        int lowerBound = 0;
+        int higherBound = MAX_KEYS_PER_READ_REQUEST;
+        int keysLeft = keys.size();
+        List<Entity> result = new ArrayList<>(keys.size());
+        for (int i = 0; i < pageCount; i++) {
+            List<Key> keysPage = keys.subList(lowerBound, higherBound);
+            List<Entity> page = fetch(keysPage);
+            result.addAll(page);
+
+            keysLeft -= keysPage.size();
+            lowerBound = higherBound;
+            higherBound += min(keysLeft, MAX_KEYS_PER_READ_REQUEST);
+        }
+
+        return result;
+    }
+
+    private List<Entity> fetch(List<Key> keys) {
+        Key[] keysArray = new Key[keys.size()];
+        keys.toArray(keysArray);
+        return datastore.fetch(keysArray);
+    }
+}

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -38,11 +38,6 @@ import static java.util.Optional.ofNullable;
 
 /**
  * A Cloud Datastore transaction wrapper.
- *
- * @implNote The wrapper provides API for basic operations which can be done transactionally.
- *         There is no mechanism for a bulk write, since the limits on a single transaction
- *         {@code Commit} operation are lower than the limits on a single {@code Put} operation.
- * @see <a href="https://cloud.google.com/datastore/docs/concepts/limits">Transaction limits</a>
  */
 public final class TransactionWrapper implements AutoCloseable {
 
@@ -96,7 +91,13 @@ public final class TransactionWrapper implements AutoCloseable {
     }
 
     /**
-     * Puts the given entity into the Datastore in the transaction.
+     * Puts the given entities into the Datastore in the transaction.
+     *
+     * @implNote Unlike {@link DatastoreWrapper}, {@code TransactionWrapper} does not provide
+     *         a mechanism for writing large numbers of entities. Only 500 entities can be written
+     *         in a single transaction. Please see
+     *         the <a href="https://cloud.google.com/datastore/docs/concepts/limits">transaction
+     *         limits</a> for more info.
      */
     public void createOrUpdate(Collection<Entity> entities) throws DatastoreException {
         Entity[] array = new Entity[entities.size()];

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -139,7 +139,7 @@ public final class TransactionWrapper implements AutoCloseable {
      * @return results fo the query as a lazily evaluated {@link Iterator}
      */
     public <R> DsQueryIterator<R> read(StructuredQuery<R> ancestorQuery) throws DatastoreException {
-        return DsQueryIterator.compose(tx, ancestorQuery, namespaceSupplier);
+        return DsQueryIterator.compose(tx, ancestorQuery, namespaceSupplier.get());
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -37,6 +37,11 @@ import static java.util.Optional.ofNullable;
 
 /**
  * A Cloud Datastore transaction wrapper.
+ *
+ * @implNote The wrapper provides API for basic operations which can be done transactionally.
+ *         There is no mechanism for a bulk write, since the limits on a single transaction
+ *         {@code Commit} operation are lower than the limits on a single {@code Put} operation.
+ * @see <a href="https://cloud.google.com/datastore/docs/concepts/limits">Transaction limits</a>
  */
 public final class TransactionWrapper implements AutoCloseable {
 
@@ -137,7 +142,8 @@ public final class TransactionWrapper implements AutoCloseable {
     /**
      * Commits this transaction.
      *
-     * @throws DatastoreException if the transaction is no longer active
+     * @throws DatastoreException
+     *         if the transaction is no longer active
      */
     public void commit() {
         tx.commit();
@@ -146,7 +152,8 @@ public final class TransactionWrapper implements AutoCloseable {
     /**
      * Rolls back this transaction.
      *
-     * @throws DatastoreException if the transaction is no longer active
+     * @throws DatastoreException
+     *         if the transaction is no longer active
      */
     public void rollback() {
         tx.rollback();

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -30,6 +30,7 @@ import io.spine.server.storage.datastore.tenant.NamespaceSupplier;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -112,6 +113,25 @@ public final class TransactionWrapper implements AutoCloseable {
     public Optional<Entity> read(Key key) {
         Entity entity = tx.get(key);
         return ofNullable(entity);
+    }
+
+    /**
+     * Retrieves an {@link Entity} for each of the given keys.
+     *
+     * <p>The results are returned in an order matching that of the provided keys
+     * with {@code null}s in place of missing and inactive entities.
+     *
+     * @param keys
+     *         {@link Key Keys} to search for
+     * @return an {@code List} of the found entities in the order of keys (including {@code null}
+     *         values for nonexistent keys)
+     * @see com.google.cloud.datastore.DatastoreReader#fetch(Key...)
+     */
+    public List<Entity> lookup(List<Key> keys) {
+        checkNotNull(keys);
+        Key[] array = new Key[keys.size()];
+        keys.toArray(array);
+        return tx.fetch(array);
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -121,10 +121,10 @@ public final class TransactionWrapper implements AutoCloseable {
      * <p>The results are returned in an order matching that of the provided keys
      * with {@code null}s in place of missing and inactive entities.
      *
-     * <p>A Datastore transaction can only access 25 entity groups over its entire lifespan. If
-     * the entities do not have ancestors, this translates to 25 entities per transaction.
-     * See the <a href="https://cloud.google.com/datastore/docs/concepts/limits">Datastore
-     * limits</a> for more info.
+     * <p>In Datastore native mode, a transaction can only access 25 entity groups over its entire
+     * lifespan. If the entities do not have ancestors, this translates to 25 entities per
+     * transaction. See the <a href="https://cloud.google.com/datastore/docs/concepts/limits">
+     * Datastore limits</a> for more info.
      *
      * @param keys
      *         {@link Key Keys} to search for

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -64,7 +64,7 @@ public final class TransactionWrapper implements AutoCloseable {
     /**
      * Puts the given entity into the Datastore in the transaction.
      */
-    public void createOrUpdate(Entity entity) {
+    public void createOrUpdate(Entity entity) throws DatastoreException {
         tx.put(entity);
     }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -28,6 +28,7 @@ import com.google.cloud.datastore.StructuredQuery;
 import com.google.cloud.datastore.Transaction;
 import io.spine.server.storage.datastore.tenant.NamespaceSupplier;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -51,6 +52,8 @@ public final class TransactionWrapper implements AutoCloseable {
     /**
      * Creates a new entity in the Datastore in the transaction.
      *
+     * <p>Throws a {@link DatastoreException} if an entity with such a key already exists.
+     *
      * @param entity
      *         new {@link Entity} to put into the Datastore
      * @throws DatastoreException
@@ -62,10 +65,37 @@ public final class TransactionWrapper implements AutoCloseable {
     }
 
     /**
+     * Creates multiple new entities in the Datastore in the transaction.
+     *
+     * <p>Throws a {@link DatastoreException} if at least one entity key clashes with an existing
+     * one.
+     *
+     * @param entities
+     *         new entities to put into the Datastore
+     * @throws DatastoreException
+     *         upon failure
+     * @see Transaction#add(com.google.cloud.datastore.FullEntity...)
+     */
+    public void create(Collection<Entity> entities) throws DatastoreException {
+        Entity[] array = new Entity[entities.size()];
+        entities.toArray(array);
+        tx.add(array);
+    }
+
+    /**
      * Puts the given entity into the Datastore in the transaction.
      */
     public void createOrUpdate(Entity entity) throws DatastoreException {
         tx.put(entity);
+    }
+
+    /**
+     * Puts the given entity into the Datastore in the transaction.
+     */
+    public void createOrUpdate(Collection<Entity> entities) throws DatastoreException {
+        Entity[] array = new Entity[entities.size()];
+        entities.toArray(array);
+        tx.put(array);
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -117,11 +117,14 @@ public final class TransactionWrapper implements AutoCloseable {
     /**
      * Queries the Datastore with the given arguments within the transaction.
      *
-     * <p>The Datastore may return a partial result set, so an execution of this method may
-     * result in several Datastore queries.
+     * <p>Datastore only supports ancestor queries within a transaction.
+     * A {@link DatastoreException} is thrown if the given query is not an ancestor query.
      *
-     * <p>The limit included in the {@link StructuredQuery}, will be a maximum count of objects
-     * in the returned iterator.
+     * <p>The Datastore may return a partial result set, so an execution of this method may result
+     * in several Datastore queries.
+     *
+     * <p>The limit included in the {@link StructuredQuery}, will be a maximum count of objects in
+     * the returned iterator.
      *
      * <p>The returned {@link DsQueryIterator} allows to {@linkplain DsQueryIterator#nextPageQuery()
      * create a query} to the next page of results reusing an existing cursor.
@@ -129,14 +132,14 @@ public final class TransactionWrapper implements AutoCloseable {
      * <p>The resulting {@code Iterator} is evaluated lazily. A call to
      * {@link Iterator#remove() Iterator.remove()} causes an {@link UnsupportedOperationException}.
      *
-     * @param query
+     * @param ancestorQuery
      *         {@link Query} to execute upon the Datastore
      * @param <R>
      *         the type of queried objects
      * @return results fo the query as a lazily evaluated {@link Iterator}
      */
-    public <R> DsQueryIterator<R> read(StructuredQuery<R> query) {
-        return DsQueryIterator.compose(tx, query, namespaceSupplier);
+    public <R> DsQueryIterator<R> read(StructuredQuery<R> ancestorQuery) throws DatastoreException {
+        return DsQueryIterator.compose(tx, ancestorQuery, namespaceSupplier);
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/TransactionWrapper.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
 
 /**
  * A Cloud Datastore transaction wrapper.
@@ -75,7 +76,7 @@ public final class TransactionWrapper implements AutoCloseable {
      */
     public Optional<Entity> read(Key key) {
         Entity entity = tx.get(key);
-        return Optional.ofNullable(entity);
+        return ofNullable(entity);
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/tenant/Namespace.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/tenant/Namespace.java
@@ -213,9 +213,17 @@ public final class Namespace {
     }
 
     /**
+     * @deprecated Use {@link #value()} instead.
+     */
+    @Deprecated
+    public String getValue() {
+        return value;
+    }
+
+    /**
      * Obtains a string value of this {@code Namespace}.
      */
-    public String getValue() {
+    public String value() {
         return value;
     }
 
@@ -231,7 +239,7 @@ public final class Namespace {
      * <pre>
      *     {@code
      *     TenantId.newBuilder()
-     *             .setValue(namespace.getValue())
+     *             .setValue(namespace.value())
      *             .vBuild();
      *     }
      * </pre>
@@ -239,13 +247,13 @@ public final class Namespace {
      * @return a {@link TenantId} represented by this {@code Namespace}
      */
     TenantId toTenantId() {
-        TenantId tenantId = converter.convert(getValue());
+        TenantId tenantId = converter.convert(value());
         return tenantId;
     }
 
     @Override
     public String toString() {
-        return getValue();
+        return value();
     }
 
     @Override
@@ -257,12 +265,12 @@ public final class Namespace {
             return false;
         }
         Namespace namespace = (Namespace) o;
-        return Objects.equal(getValue(), namespace.getValue());
+        return Objects.equal(value(), namespace.value());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getValue());
+        return Objects.hashCode(value());
     }
 
     /**

--- a/datastore/src/main/java/io/spine/server/storage/datastore/tenant/NamespaceIndex.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/tenant/NamespaceIndex.java
@@ -141,8 +141,7 @@ final class NamespaceIndex implements TenantIndex {
     boolean contains(Namespace namespace) {
         checkNotNull(namespace);
 
-        if (namespace.value()
-                     .isEmpty()) { // Default namespace, always exists
+        if (namespace.value().isEmpty()) { // Default namespace, always exists
             return true;
         }
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/tenant/NamespaceIndex.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/tenant/NamespaceIndex.java
@@ -141,7 +141,7 @@ final class NamespaceIndex implements TenantIndex {
     boolean contains(Namespace namespace) {
         checkNotNull(namespace);
 
-        if (namespace.getValue()
+        if (namespace.value()
                      .isEmpty()) { // Default namespace, always exists
             return true;
         }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
@@ -63,10 +63,8 @@ import static io.spine.server.storage.datastore.tenant.TestNamespaceSuppliers.si
 import static io.spine.testing.server.storage.datastore.TestDatastoreWrapper.wrap;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @DisplayName("`DatastoreWrapper` should")
@@ -351,18 +349,9 @@ class DatastoreWrapperTest {
         assertTrue(result.hasNext());
         Entity second = result.next();
 
-        assertThat(expctedEntities).contains(first);
-        assertThat(expctedEntities).contains(second);
-
-        assertFalse(result.hasNext());
-        assertFalse(result.hasNext());
-        assertFalse(result.hasNext());
-
-        try {
-            result.next();
-            fail();
-        } catch (NoSuchElementException ignored) {
-        }
+        assertThat(expctedEntities)
+                .containsExactly(first, second);
+        assertThrows(NoSuchElementException.class, result::next);
     }
 
     @Test

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
@@ -77,55 +77,6 @@ class DatastoreWrapperTest {
         wrapper.dropTable(NAMESPACE_HOLDER_KIND);
     }
 
-    @SuppressWarnings("deprecation") // To be deleted alongside with the tested API.
-    @Nested
-    class SingleTenant {
-
-        private DatastoreWrapper wrapper;
-
-        @BeforeEach
-        void setUp() {
-            wrapper = wrap(localDatastore(), singleTenant());
-            wrapper.startTransaction();
-        }
-
-        @Test
-        @DisplayName("work with transactions if necessary")
-        void testExecuteTransactions() {
-            assertTrue(wrapper.isTransactionActive());
-            wrapper.commitTransaction();
-            assertFalse(wrapper.isTransactionActive());
-        }
-
-        @Test
-        @DisplayName("rollback transactions")
-        void testRollback() {
-            assertTrue(wrapper.isTransactionActive());
-            wrapper.rollbackTransaction();
-            assertFalse(wrapper.isTransactionActive());
-        }
-
-        @Test
-        @DisplayName("fail to start transaction if one is active")
-        void testFailToRestartTransactions() {
-            try {
-                assertTrue(wrapper.isTransactionActive());
-                assertThrows(IllegalStateException.class, wrapper::startTransaction);
-            } finally {
-                wrapper.rollbackTransaction();
-            }
-        }
-
-        @Test
-        @DisplayName("fail to finish non active transaction")
-        void testFailToFinishNonActiveTransaction() {
-            assertTrue(wrapper.isTransactionActive());
-            wrapper.commitTransaction();
-            assertFalse(wrapper.isTransactionActive());
-            assertThrows(IllegalStateException.class, wrapper::rollbackTransaction);
-        }
-    }
-
     @Nested
     class NotWaiting {
 

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
@@ -30,6 +30,7 @@ import io.spine.core.TenantId;
 import io.spine.net.EmailAddress;
 import io.spine.net.InternetDomain;
 import io.spine.server.tenant.TenantAwareFunction0;
+import io.spine.testing.SlowTest;
 import io.spine.testing.server.storage.datastore.TestDatastoreWrapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -92,6 +93,7 @@ class DatastoreWrapperTest {
             wrapper.dropAllTables();
         }
 
+        @SlowTest
         @Test
         @DisplayName("support bulk reads")
         void testBulkRead() throws InterruptedException {
@@ -110,6 +112,7 @@ class DatastoreWrapperTest {
             assertTrue(expectedEntities.containsAll(readEntities));
         }
 
+        @SlowTest
         @Test
         @DisplayName("support big bulk reads")
         void testBigBulkRead() throws InterruptedException {
@@ -156,6 +159,7 @@ class DatastoreWrapperTest {
             wrapper.dropAllTables();
         }
 
+        @SlowTest
         @Test
         @DisplayName("read and write entities in the remote datastore")
         void testBulkRead() {
@@ -189,6 +193,7 @@ class DatastoreWrapperTest {
             wrapper.dropAllTables();
         }
 
+        @SlowTest
         @Test
         @DisplayName("replacing missing entities with null")
         void testMissingAreNull() throws InterruptedException {
@@ -220,6 +225,7 @@ class DatastoreWrapperTest {
             assertFalse(actualEntities.hasNext());
         }
 
+        @SlowTest
         @Test
         @DisplayName("preserving order")
         void test() throws InterruptedException {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DatastoreWrapperTest.java
@@ -379,7 +379,7 @@ class DatastoreWrapperTest {
         Key entityKey = new TenantAwareFunction0<Key>(tenantId) {
             @Override
             public Key apply() {
-                Key entityKey = wrapper.keyFactory(Kind.of(NAMESPACE_HOLDER_KIND))
+                Key entityKey = wrapper.keyFactory(NAMESPACE_HOLDER_KIND)
                                        .newKey(key);
                 Entity entity = Entity.newBuilder(entityKey)
                                       .build();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
@@ -38,7 +38,6 @@ import io.spine.server.storage.datastore.given.DsInboxStorageTestEnv;
 import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -94,7 +93,6 @@ class DsInboxStorageTest extends InboxStorageTest {
         readAndCompare(storage, anotherMsg);
     }
 
-    @Disabled
     @Test
     @DisplayName("read and write multiple `InboxMessage` instances")
     void readAndWriteMultipleMessages() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
@@ -41,15 +41,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Time.currentTime;
 import static io.spine.server.delivery.InboxMessageStatus.TO_DELIVER;
 import static io.spine.server.storage.datastore.given.DsInboxStorageTestEnv.generate;
 import static io.spine.server.storage.datastore.given.TestShardIndex.newIndex;
-import static java.util.stream.Collectors.toList;
+import static java.util.Comparator.comparing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,7 +96,6 @@ class DsInboxStorageTest extends InboxStorageTest {
     @Test
     @DisplayName("read and write multiple `InboxMessage` instances")
     void readAndWriteMultipleMessages() {
-
         InboxStorage storage = storage();
         int totalMessages = 10;
         ShardIndex index = newIndex(1, 18);
@@ -108,13 +107,8 @@ class DsInboxStorageTest extends InboxStorageTest {
         storage.writeAll(messages);
 
         ImmutableList<InboxMessage> contents = readAllAndCompare(storage, index, messages);
-        List<InboxMessage> chronologicallySorted =
-                contents.stream()
-                        .sorted((m1, m2) -> Timestamps.compare(m1.getWhenReceived(),
-                                                               m2.getWhenReceived()))
-                        .collect(toList());
-
-        assertEquals(contents, chronologicallySorted);
+        assertThat(contents)
+             .isInStrictOrder(comparing(InboxMessage::getWhenReceived, Timestamps.comparator()));
     }
 
     @Test
@@ -159,7 +153,6 @@ class DsInboxStorageTest extends InboxStorageTest {
     @Test
     @DisplayName("mark messages delivered")
     void markMessagedDelivered() {
-
         ShardIndex index = newIndex(3, 71);
         ImmutableList<InboxMessage> messages = generate(10, index);
         InboxStorage storage = storage();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsInboxStorageTest.java
@@ -38,6 +38,7 @@ import io.spine.server.storage.datastore.given.DsInboxStorageTestEnv;
 import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +94,7 @@ class DsInboxStorageTest extends InboxStorageTest {
         readAndCompare(storage, anotherMsg);
     }
 
+    @Disabled
     @Test
     @DisplayName("read and write multiple `InboxMessage` instances")
     void readAndWriteMultipleMessages() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -376,11 +376,13 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
 
             // Check the query results.
             List<EntityRecord> resultList = newArrayList(readResult);
-            assertEquals(1, resultList.size());
+            assertThat(resultList)
+                    .hasSize(1);
 
             // Check the record state.
             EntityRecord record = resultList.get(0);
-            assertEquals(targetEntity.state(), unpack(record.getState()));
+            assertThat(unpack(record.getState()))
+                    .isEqualTo(targetEntity.state());
 
             assertDsReadByKeys();
         }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -56,6 +56,7 @@ import io.spine.test.datastore.CollegeId;
 import io.spine.test.storage.Project;
 import io.spine.test.storage.ProjectId;
 import io.spine.test.storage.Task;
+import io.spine.testing.SlowTest;
 import io.spine.testing.server.storage.datastore.SpyStorageFactory;
 import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
 import io.spine.type.TypeUrl;
@@ -275,6 +276,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
         assertEquals(entity.isDeleted(), datastoreEntity.getBoolean(deleted));
     }
 
+    @SlowTest
     @Test
     @DisplayName("pass big data speed test")
     void testBigData() {
@@ -885,6 +887,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             assertDsReadByStructuredQuery();
         }
 
+        @SlowTest
         @Test
         @DisplayName("with multiple Datastore reads")
         void performsMultipleReads() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.datastore.Key;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.IterableSubject;
 import com.google.protobuf.Any;
+import com.google.protobuf.Duration;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import io.spine.base.EntityState;
@@ -62,7 +63,6 @@ import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
 import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -76,6 +76,9 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.reverse;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.protobuf.util.Durations.fromSeconds;
+import static com.google.protobuf.util.Timestamps.add;
+import static com.google.protobuf.util.Timestamps.subtract;
 import static com.google.protobuf.util.Timestamps.toSeconds;
 import static io.spine.client.Filters.all;
 import static io.spine.client.Filters.either;
@@ -350,7 +353,6 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             storage = storageFactory.createRecordStorage(contextSpec, CollegeEntity.class);
         }
 
-        @Disabled
         @Test
         @DisplayName("returning proper entity")
         void testQueryByIDs() {
@@ -366,7 +368,11 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
 
             // Create column filter.
             Timestamp targetColumnValue = targetEntity.getCreated();
-            CompositeFilter columnFilter = all(eq(CREATED.columnName(), targetColumnValue));
+            Duration oneSecond = fromSeconds(1);
+            CompositeFilter columnFilter = all(
+                    gt(CREATED.columnName(), subtract(targetColumnValue, oneSecond)),
+                    lt(CREATED.columnName(), add(targetColumnValue, oneSecond))
+            );
 
             // Compose Query filters.
             TargetFilters entityFilters = newTargetFilters(idFilter, columnFilter);

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsRecordStorageTest.java
@@ -61,6 +61,7 @@ import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
 import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -347,6 +348,7 @@ class DsRecordStorageTest extends RecordStorageTest<DsRecordStorage<ProjectId>> 
             storage = storageFactory.createRecordStorage(contextSpec, CollegeEntity.class);
         }
 
+        @Disabled
         @Test
         @DisplayName("returning proper entity")
         void testQueryByIDs() {

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -294,7 +294,7 @@ class TransactionWrapperTest {
         );
         try (TransactionWrapper tx = datastore.newTransaction()) {
             List<Entity> readEntities = tx.lookup(keys);
-            tx.close();
+            tx.commit();
             assertThat(readEntities)
                     .containsExactly(firstEntity, null, secondEntity);
         }
@@ -318,7 +318,7 @@ class TransactionWrapperTest {
                                .collect(toList());
         try (TransactionWrapper tx = datastore.newTransaction()) {
             List<Entity> readEntities = tx.lookup(keys);
-            tx.close();
+            tx.commit();
             assertThat(readEntities)
                     .containsExactlyElementsIn(entities);
         }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -217,7 +217,6 @@ class TransactionWrapperTest {
         int count = 100;
         KeyFactory ancestorFactory = keyFactory
                 .addAncestor(PathElement.of(TEST_KIND.value(), newUuid()));
-        String propertyName = "random_number";
         Entity[] entities = generate(() -> ancestorFactory.newKey(newUuid()))
                 .limit(count)
                 .map(key -> Entity.newBuilder(key).build())

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -26,7 +26,6 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.PathElement;
 import com.google.cloud.datastore.Query;
-import com.google.common.base.Preconditions;
 import com.google.protobuf.Empty;
 import io.spine.testing.SlowTest;
 import io.spine.testing.server.storage.datastore.TestDatastoreWrapper;
@@ -64,12 +63,12 @@ class TransactionWrapperTest {
     void setUp() {
         datastore = TestDatastoreWrapper.wrap(localDatastore(), false);
         keyFactory = datastore.keyFactory(TEST_KIND);
+
     }
 
     @AfterEach
     void cleanUpDatastore() {
         datastore.dropAllTables();
-        keyFactory.reset();
     }
 
     @Test

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -214,15 +214,13 @@ class TransactionWrapperTest {
     @Test
     @DisplayName("run a single read operation for many entities")
     void bulkRead() {
-        int count = 10_000;
+        int count = 100;
         KeyFactory ancestorFactory = keyFactory
                 .addAncestor(PathElement.of(TEST_KIND.value(), newUuid()));
         String propertyName = "random_number";
-        Entity[] entities = generate(() -> keyFactory.newKey(newUuid()))
+        Entity[] entities = generate(() -> ancestorFactory.newKey(newUuid()))
                 .limit(count)
-                .map(key -> Entity.newBuilder(key)
-                                  .set(propertyName, random(1, 3))
-                                  .build())
+                .map(key -> Entity.newBuilder(key).build())
                 .toArray(Entity[]::new);
         datastore.createOrUpdate(entities);
 
@@ -234,7 +232,7 @@ class TransactionWrapperTest {
                                                                 .build());
             List<Entity> allEntities = newArrayList(readEntities);
             IntegerSubject assertSize = assertThat(allEntities.size());
-            assertSize.isAtLeast(1000);
+            assertSize.isAtLeast(10);
             assertSize.isAtMost(count);
             tx.commit();
         }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -236,7 +236,7 @@ class TransactionWrapperTest {
 
     @Test
     @DisplayName("fail early on `create` if entity already exists")
-    void insert() {
+    void insertTwice() {
         Key key = keyFactory.newKey(newUuid());
         Entity entity = Entity.newBuilder(key).build();
         try (TransactionWrapper tx = datastore.newTransaction()) {
@@ -253,7 +253,7 @@ class TransactionWrapperTest {
 
     @Test
     @DisplayName("fail on `create` if entity existed before transaction")
-    void allowDuplicateIfOutOfTx() {
+    void insert() {
         Key key = keyFactory.newKey(newUuid());
         String propertyName = "randomValue";
         Entity oldEntity = Entity.newBuilder(key).build();

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -305,6 +305,7 @@ class TransactionWrapperTest {
     @DisplayName("read many entities by IDs")
     void lookupBulk() {
         int count = 2020;
+        keyFactory.addAncestor(PathElement.of(TEST_KIND.value(), newUuid()));
         Entity[] entities = generate(() -> keyFactory.newKey(newUuid()))
                 .limit(count)
                 .map(key -> Entity.newBuilder(key)

--- a/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/TransactionWrapperTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.PathElement;
 import com.google.cloud.datastore.Query;
+import com.google.common.base.Preconditions;
 import com.google.protobuf.Empty;
 import io.spine.testing.SlowTest;
 import io.spine.testing.server.storage.datastore.TestDatastoreWrapper;
@@ -68,6 +69,7 @@ class TransactionWrapperTest {
     @AfterEach
     void cleanUpDatastore() {
         datastore.dropAllTables();
+        keyFactory.reset();
     }
 
     @Test

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/CountingDatastoreWrapper.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/CountingDatastoreWrapper.java
@@ -29,7 +29,6 @@ import io.spine.testing.server.storage.datastore.TestDatastoreWrapper;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -51,11 +50,6 @@ public final class CountingDatastoreWrapper extends TestDatastoreWrapper {
         Entity result = super.read(key);
         readByKeysCount++;
         return result;
-    }
-
-    @Override
-    public Iterator<@Nullable Entity> read(Iterable<Key> keys) {
-        return lookup(keys).iterator();
     }
 
     @Override

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/CountingDatastoreWrapper.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/CountingDatastoreWrapper.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A {@link TestDatastoreWrapper} which counts the number of calls for certain types of Datastore
@@ -54,7 +55,12 @@ public final class CountingDatastoreWrapper extends TestDatastoreWrapper {
 
     @Override
     public Iterator<@Nullable Entity> read(Iterable<Key> keys) {
-        Iterator<@Nullable Entity> result = super.read(keys);
+        return lookup(keys).iterator();
+    }
+
+    @Override
+    public List<@Nullable Entity> lookup(Iterable<Key> keys) {
+        List<@Nullable Entity> result = super.lookup(keys);
         readByKeysCount++;
         return result;
     }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/CountingDatastoreWrapper.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/CountingDatastoreWrapper.java
@@ -53,7 +53,7 @@ public final class CountingDatastoreWrapper extends TestDatastoreWrapper {
     }
 
     @Override
-    public List<@Nullable Entity> lookup(Iterable<Key> keys) {
+    public List<@Nullable Entity> lookup(Collection<Key> keys) {
         List<@Nullable Entity> result = super.lookup(keys);
         readByKeysCount++;
         return result;

--- a/datastore/src/test/java/io/spine/server/storage/datastore/given/DatastoreWrapperTestEnv.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/given/DatastoreWrapperTestEnv.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class DatastoreWrapperTestEnv {
 
-    public static final String NAMESPACE_HOLDER_KIND = "spine.test.NAMESPACE_HOLDER_KIND";
+    public static final Kind NAMESPACE_HOLDER_KIND = Kind.of("spine.test.NAMESPACE_HOLDER_KIND");
     public static final Kind GENERIC_ENTITY_KIND = Kind.of("my.entity");
 
     private static final String SERVICE_ACCOUNT_RESOURCE_PATH = "spine-dev.json";
@@ -62,7 +62,7 @@ public class DatastoreWrapperTestEnv {
     public static void ensureNamespace(String namespaceValue, Datastore datastore) {
         KeyFactory keyFactory = datastore.newKeyFactory()
                                          .setNamespace(namespaceValue)
-                                         .setKind(NAMESPACE_HOLDER_KIND);
+                                         .setKind(NAMESPACE_HOLDER_KIND.value());
         Entity entity = Entity.newBuilder(keyFactory.newKey(42L))
                               .build();
         datastore.put(entity);

--- a/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceConvertersTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceConvertersTest.java
@@ -48,12 +48,12 @@ class NamespaceConvertersTest extends UtilityClassTest<NamespaceConverters> {
         NamespaceConverter converter = NamespaceConverters.forCustomNamespace();
         Namespace namespace = Namespace.of("namespace");
         TenantId fromInternalConverter = namespace.toTenantId();
-        TenantId fromExternalConverter = converter.convert(namespace.getValue());
+        TenantId fromExternalConverter = converter.convert(namespace.value());
 
         assertEquals(fromInternalConverter, fromExternalConverter);
 
         String restored = converter.reverse()
                                    .convert(fromExternalConverter);
-        assertEquals(namespace.getValue(), restored);
+        assertEquals(namespace.value(), restored);
     }
 }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceTest.java
@@ -184,6 +184,6 @@ class NamespaceTest {
                      .build();
         Namespace namespace = Namespace.fromNameOf(key, multitenant);
         assertNotNull(namespace);
-        assertEquals(ns, namespace.getValue());
+        assertEquals(ns, namespace.value());
     }
 }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceWithCustomConverterTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceWithCustomConverterTest.java
@@ -51,7 +51,7 @@ class NamespaceWithCustomConverterTest {
         NamespaceConverter converter = factory.get(multitenant);
         assertNotNull(converter);
         assertEquals(converter.reverse()
-                              .convert(tenantId), namespace.getValue());
+                              .convert(tenantId), namespace.value());
     }
 
     @Test
@@ -62,7 +62,7 @@ class NamespaceWithCustomConverterTest {
                      .build();
         Namespace namespace = Namespace.fromNameOf(key, true, factory);
         assertNotNull(namespace);
-        assertEquals(ns, namespace.getValue());
+        assertEquals(ns, namespace.value());
     }
 
     @Test

--- a/datastore/src/test/java/io/spine/server/storage/datastore/tenant/SingleTenantNamespaceSupplierTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/tenant/SingleTenantNamespaceSupplierTest.java
@@ -45,7 +45,7 @@ class SingleTenantNamespaceSupplierTest {
         NamespaceSupplier supplier = NamespaceSupplier.singleTenant();
         Namespace namespace = supplier.get();
         assertNotNull(namespace);
-        assertThat(namespace.getValue(), isEmptyString());
+        assertThat(namespace.value(), isEmptyString());
         TenantId tenantId = namespace.toTenantId();
         assertThat(tenantId, isEffectivelyDefault());
     }
@@ -57,7 +57,7 @@ class SingleTenantNamespaceSupplierTest {
         NamespaceSupplier supplier = NamespaceSupplier.singleTenant(namespaceValue);
         Namespace namespace = supplier.get();
         assertNotNull(namespace);
-        assertEquals(namespaceValue, namespace.getValue());
+        assertEquals(namespaceValue, namespace.value());
 
         TenantId tenantId = namespace.toTenantId();
         assertThat(tenantId, not(isEffectivelyDefault()));

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.4.0`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.4.1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.10.0
@@ -650,12 +650,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jan 08 14:15:00 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:02:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.4.0`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.4.1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.9
@@ -1309,12 +1309,12 @@ This report was generated on **Wed Jan 08 14:15:00 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jan 08 14:15:02 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:02:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.4.0`
+# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.4.1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.10.0
@@ -1985,4 +1985,4 @@ This report was generated on **Wed Jan 08 14:15:02 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jan 08 14:15:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:02:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:02:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:20:56 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Mon Jan 27 14:02:43 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:02:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:20:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Mon Jan 27 14:02:48 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:02:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:21:00 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 16:48:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 19:53:25 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Mon Jan 27 16:48:06 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 16:48:24 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 19:53:27 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Mon Jan 27 16:48:24 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 16:48:33 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 19:53:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:52:53 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:48:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Mon Jan 27 14:52:53 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:52:55 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:48:24 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Mon Jan 27 14:52:55 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:52:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:48:33 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 19:53:25 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 20:04:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Mon Jan 27 19:53:25 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 19:53:27 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 20:04:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Mon Jan 27 19:53:27 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 19:53:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 20:04:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jan 28 17:05:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 28 17:24:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Tue Jan 28 17:05:29 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jan 28 17:05:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 28 17:24:59 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Tue Jan 28 17:05:31 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jan 28 17:05:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 28 17:25:01 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:20:56 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:52:53 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Mon Jan 27 14:20:56 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:20:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:52:55 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Mon Jan 27 14:20:58 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 14:21:00 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 14:52:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -650,7 +650,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 20:04:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 28 17:05:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1309,7 +1309,7 @@ This report was generated on **Mon Jan 27 20:04:36 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 20:04:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 28 17:05:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1985,4 +1985,4 @@ This report was generated on **Mon Jan 27 20:04:38 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 27 20:04:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 28 17:05:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.4.0</version>
+<version>1.4.1</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,7 +40,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -58,7 +58,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -114,12 +114,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.3</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.3</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/testutil-gcloud/src/main/java/io/spine/testing/server/storage/datastore/TestDatastoreWrapper.java
+++ b/testutil-gcloud/src/main/java/io/spine/testing/server/storage/datastore/TestDatastoreWrapper.java
@@ -55,7 +55,7 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
     private static final int CONSISTENCY_AWAIT_ITERATIONS = 20;
 
     /**
-     * Due to eventual consistency, {@linkplain #dropTable(String) is performed iteratively until
+     * Due to eventual consistency, {@linkplain #dropTable(Kind) is performed iteratively until
      * the table has no records}.
      *
      * <p>This constant represents the maximum number of cleanup attempts before the execution
@@ -63,7 +63,7 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
      */
     private static final int MAX_CLEANUP_ATTEMPTS = 5;
 
-    private static final Collection<String> kindsCache = new ArrayList<>();
+    private static final Collection<Kind> kindsCache = new ArrayList<>();
 
     private final boolean waitForConsistency;
 
@@ -88,7 +88,8 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
 
     @Override
     public KeyFactory keyFactory(Kind kind) {
-        kindsCache.add(kind.value());
+        checkNotNull(kind);
+        kindsCache.add(kind);
         return super.keyFactory(kind);
     }
 
@@ -111,7 +112,7 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
     }
 
     @Override
-    protected void dropTable(String table) {
+    protected void dropTable(Kind table) {
         if (!waitForConsistency) {
             super.dropTable(table);
         } else {
@@ -120,7 +121,7 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
     }
 
     @SuppressWarnings("BusyWait")   // allows Datastore some time between cleanup attempts.
-    private void dropTableConsistently(String table) {
+    private void dropTableConsistently(Kind table) {
         Integer remainingEntityCount = null;
         int cleanupAttempts = 0;
 
@@ -138,7 +139,7 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
             }
 
             StructuredQuery<Entity> query = Query.newEntityQueryBuilder()
-                                                 .setKind(table)
+                                                 .setKind(table.value())
                                                  .build();
             List<Entity> entities = newArrayList(read(query));
             remainingEntityCount = entities.size();
@@ -183,7 +184,7 @@ public class TestDatastoreWrapper extends DatastoreWrapper {
      */
     public void dropAllTables() {
         _debug().log("Dropping all tables...");
-        for (String kind : kindsCache) {
+        for (Kind kind : kindsCache) {
             dropTable(kind);
         }
 

--- a/version.gradle
+++ b/version.gradle
@@ -25,13 +25,11 @@
  * {@code .config/gradle/dependencies.gradle}.
  */
 
-def final SPINE_VERSION = '1.4.0'
-
 ext {
-    versionToPublish = SPINE_VERSION
+    versionToPublish = '1.4.1'
     
-    spineBaseVersion = SPINE_VERSION
-    spineCoreVersion = SPINE_VERSION
+    spineBaseVersion = '1.4.3'
+    spineCoreVersion = '1.4.4'
 
     datastoreVersion = '1.102.0'
 }


### PR DESCRIPTION
This PR updates the API of the Cloud Datastore-based storage. In particular, we make it easier to work with transactions. The new methods of `TransactionWrapper` cover all the necessary database operations.

Also, in this PR, we update the format of `InboxMessage` storage. Previously, `InboxMessage`s had a Timestamp property `when_received`. However, with the latest time-related changes in the framework, the precision of the Datastore Timestamp is now not enough for us. Thus, we introduce a new column `received_at`, which contains the number of nanoseconds, elapsed since the Unix epoch start. Though nanoseconds are, strictly speaking, a lie, this is good enough for our technical purposes.

As another side effect of the time-related changes, the standard idiom for querying entities by a time-based property has changed. Instead of passing an `equals` filter, it is recommended to
 1) pass an `equals` filter with a value rounded down to a whole microsecond;
 2) or pass a greater than - less than filter with a span of ± 1 second.