### PR TITLE
Release 1.5.21

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,9 +19,7 @@
  */
 
 plugins {
-    // Use Kotlin for `buildSrc`.
-    // https://kotlinlang.org/docs/reference/using-gradle.html#targeting-the-jvm
-    kotlin("jvm").version("1.3.72")
+    `kotlin-dsl`
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -22,9 +22,9 @@ package io.spine.gradle.internal
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.net.URL
@@ -33,7 +33,7 @@ import java.net.URL
  * A task which verifies that the current version of the library has not been published to the given
  * Maven repository yet.
  */
-open class CheckVersionIncrement : AbstractTask() {
+open class CheckVersionIncrement : DefaultTask() {
 
     /**
      * The Maven repository in which to look for published artifacts.
@@ -45,7 +45,7 @@ open class CheckVersionIncrement : AbstractTask() {
     lateinit var repository: Repository
 
     @Input
-    private val version: String = project.version as String
+    val version: String = project.version as String
 
     @TaskAction
     private fun fetchAndCheck() {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -37,10 +37,10 @@ class IncrementGuard : Plugin<Project> {
     override fun apply(target: Project) {
         val tasks = target.tasks
         tasks.register(taskName, CheckVersionIncrement::class.java) {
-            it.repository = PublishingRepos.cloudRepo
-            tasks.getByName("check").dependsOn(it)
+            repository = PublishingRepos.cloudRepo
+            tasks.getByName("check").dependsOn(this)
 
-            it.shouldRunAfter("test")
+            shouldRunAfter("test")
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -20,8 +20,9 @@
 
 package io.spine.gradle.internal
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 import java.io.File
@@ -35,11 +36,12 @@ import java.io.File
  * The build writes verbose log into `$directory/build/debug-out.txt`. The error output is written
  * into `$directory/build/error-out.txt`.
  */
-open class RunBuild : AbstractTask() {
+open class RunBuild : DefaultTask() {
 
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */
+    @Internal
     lateinit var directory: String
 
     @TaskAction

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -70,8 +70,8 @@ object Versions {
     val checkerFramework = "3.3.0"
     val errorProne       = "2.3.4"
     val errorProneJavac  = "9+181-r4173-1" // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
-    val errorPronePlugin = "1.1.1"
-    val pmd              = "6.20.0"
+    val errorPronePlugin = "1.2.1"
+    val pmd              = "6.24.0"
     val checkstyle       = "8.29"
     val protobufPlugin   = "0.8.12"
     val appengineApi     = "1.9.79"
@@ -97,11 +97,12 @@ object Versions {
     val jackson          = "2.9.10.4"
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
+    val javaxAnnotation  = "1.3.2"
 
     /**
      * Version of the SLF4J library.
      *
-     * Spine used to log with SLF4J. Now we use Flogger. Whenever a coice comes up, we recommend to
+     * Spine used to log with SLF4J. Now we use Flogger. Whenever a choice comes up, we recommend to
      * use the latter.
      *
      * Some third-party libraries may clash with different versions of the library. Thus, we specify
@@ -163,7 +164,8 @@ object Build {
 }
 
 object Gen {
-    val javaPoet = "com.squareup:javapoet:${Versions.javaPoet}"
+    val javaPoet        = "com.squareup:javapoet:${Versions.javaPoet}"
+    val javaxAnnotation = "javax.annotation:javax.annotation-api:${Versions.javaxAnnotation}"
 }
 
 object Grpc {
@@ -227,7 +229,7 @@ object Test {
             "com.google.truth.extensions:truth-proto-extension:${Versions.truth}"
     )
     @Deprecated("Use Flogger over SLF4J.",
-                replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
+            replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j         = "org.slf4j:slf4j-jdk14:${Versions.slf4j}"
 }
@@ -278,12 +280,12 @@ object Deps {
 object DependencyResolution {
 
     fun forceConfiguration(configurations: ConfigurationContainer) {
-        configurations.all { config ->
-            config.resolutionStrategy { strategy ->
-                strategy.failOnVersionConflict()
-                strategy.cacheChangingModulesFor(0, "seconds")
+        configurations.all {
+            resolutionStrategy {
+                failOnVersionConflict()
+                cacheChangingModulesFor(0, "seconds")
                 @Suppress("DEPRECATION") // Force SLF4J version.
-                strategy.force(
+                force(
                         Deps.build.slf4j,
                         Deps.build.errorProneAnnotations,
                         Deps.build.jsr305Annotations,
@@ -329,17 +331,17 @@ object DependencyResolution {
 
     fun defaultRepositories(repositories: RepositoryHandler) {
         repositories.mavenLocal()
-        repositories.maven { repository ->
-            repository.url = URI(Repos.spine)
-            repository.content { descriptor ->
-                descriptor.includeGroup("io.spine")
-                descriptor.includeGroup("io.spine.tools")
-                descriptor.includeGroup("io.spine.gcloud")
+        repositories.maven {
+            url = URI(Repos.spine)
+            content {
+                includeGroup("io.spine")
+                includeGroup("io.spine.tools")
+                includeGroup("io.spine.gcloud")
             }
         }
         repositories.jcenter()
-        repositories.maven { repository ->
-            repository.url = URI(Repos.gradlePlugins)
+        repositories.maven {
+            url = URI(Repos.gradlePlugins)
         }
     }
 }

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Streams;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import io.spine.base.Tests;
 import io.spine.core.Event;
 import io.spine.core.Version;
 import io.spine.protobuf.AnyPacker;
@@ -238,7 +239,7 @@ class DsAggregateStorageTest extends AggregateStorageTest {
         @BeforeEach
         void setUp() {
             ServerEnvironment.instance()
-                             .configureStorage(datastoreFactory);
+                             .use(datastoreFactory, Tests.class);
             repository = new ProjectAggregateRepository();
             BoundedContext.singleTenant(DsAggregateStorageTest.class.getName())
                           .add(repository)

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTruncationTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsAggregateStorageTruncationTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.datastore;
 
+import io.spine.base.Tests;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.aggregate.AggregateStorageTruncationTest;
 import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory;
@@ -33,7 +34,7 @@ public class DsAggregateStorageTruncationTest extends AggregateStorageTruncation
     @BeforeAll
     static void prepareStorageFactory() {
         ServerEnvironment.instance()
-                         .configureStorageForTests(TestDatastoreStorageFactory.local());
+                         .use(TestDatastoreStorageFactory.local(), Tests.class);
     }
 
     @AfterAll

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsCatchUpSmokeTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsCatchUpSmokeTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.datastore;
 
+import io.spine.base.Tests;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.delivery.CatchUpTest;
 import io.spine.testing.SlowTest;
@@ -46,7 +47,7 @@ class DsCatchUpSmokeTest extends CatchUpTest {
     public void setUp() {
         factory = TestDatastoreStorageFactory.local();
         ServerEnvironment.instance()
-                         .configureStorageForTests(factory);
+                         .use(factory, Tests.class);
     }
 
     @Override

--- a/datastore/src/test/java/io/spine/server/storage/datastore/DsDeliverySmokeTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/DsDeliverySmokeTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.datastore;
 
+import io.spine.base.Tests;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.delivery.DeliveryTest;
 import io.spine.testing.SlowTest;
@@ -48,7 +49,7 @@ public class DsDeliverySmokeTest extends DeliveryTest {
         super.setUp();
         factory = TestDatastoreStorageFactory.local();
         ServerEnvironment.instance()
-                         .configureStorageForTests(factory);
+                         .use(factory, Tests.class);
     }
 
     @AfterEach

--- a/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceIndexTest.java
+++ b/datastore/src/test/java/io/spine/server/storage/datastore/tenant/NamespaceIndexTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.datastore.Key;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.IterableSubject;
 import io.spine.base.Identifier;
+import io.spine.base.Tests;
 import io.spine.core.TenantId;
 import io.spine.net.InternetDomain;
 import io.spine.server.BoundedContext;
@@ -164,7 +165,7 @@ class NamespaceIndexTest {
                 .setDatastore(datastore)
                 .build();
         ServerEnvironment.instance()
-                         .configureStorage(storageFactory);
+                         .use(storageFactory, Tests.class);
         storageFactory.configureTenantIndex(contextBuilder);
         BoundedContext context = contextBuilder.build();
         RecordStorage<String> storage = storageFactory

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  * `.config/gradle/dependencies.gradle`.
  */
 
-val spineCoreVersion: String by extra("1.5.14")
+val spineCoreVersion: String by extra("1.5.21")
 val versionToPublish: String by extra(spineCoreVersion)
-val spineBaseVersion: String by extra("1.5.12")
+val spineBaseVersion: String by extra("1.5.21")


### PR DESCRIPTION
This PR updates the version of the library to 1.5.21.

This includes the update of the `config` module and the Spine libraries that this project depends on.

Usage of now-deprecated API has been fixed.