### PR TITLE
Add missing steps to GitHub `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,6 @@ jobs:
         env:
           GCS_CREDENTIALS_KEY: ${{ secrets.GCS_CREDENTIALS_KEY }}
 
-        # Install the utility and override the
       - name: Install GCloud Tools utility
         run: chmod +x ./scripts/install-gcloud.sh && ./scripts/install-gcloud.sh
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,16 @@ jobs:
         env:
           GCS_CREDENTIALS_KEY: ${{ secrets.GCS_CREDENTIALS_KEY }}
 
+        # Install the utility and override the
+      - name: Install GCloud Tools utility
+        run: chmod +x ./scripts/install-gcloud.sh && ./scripts/install-gcloud.sh
+
+      - name: Add the newly installed GCloud SDK to PATH
+        run: source $HOME/google-cloud-sdk/path.bash.inc
+
+      - name: Start Datastore emulator
+        run: ./scripts/start-datastore.sh &
+
       - name: Publish artifacts to Maven
         run: ./gradlew build publish --stacktrace
         env:

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -33,4 +33,4 @@
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.34")
 val spineCoreVersion: String by extra("2.0.0-SNAPSHOT.25")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.2")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.3")


### PR DESCRIPTION
This changeset ensures that GCloud SDK is installed and the Datastore emulator is launched before the project is built.

The version of the library is set to `2.0.0-SNAPSHOT.3`.