### PR TITLE
Release 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Gradle:
 ```kotlin
 dependencies {
     // Datastore Storage support library.
-    implementation("io.spine.gcloud:spine-datastore:1.7.0")
+    implementation("io.spine.gcloud:spine-datastore:1.8.0")
 
     // Pub/Sub messaging support library.
-    implementation("io.spine.gcloud:spine-pubsub:1.7.0")
+    implementation("io.spine.gcloud:spine-pubsub:1.8.0")
 
     // Stackdriver Trace support library.
-    implementation("io.spine.gcloud:spine-stackdriver-trace:1.7.0")
+    implementation("io.spine.gcloud:spine-stackdriver-trace:1.8.0")
 
     // Datastore-related test utilities (if needed).
-    implementation("io.spine.gcloud:testutil-gcloud:1.7.0")
+    implementation("io.spine.gcloud:testutil-gcloud:1.8.0")
 }
 ```
 

--- a/datastore/src/main/java/io/spine/server/storage/datastore/DsSessionStorage.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/DsSessionStorage.java
@@ -34,6 +34,7 @@ import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.TimestampValue;
 import io.spine.server.delivery.ShardIndex;
 import io.spine.server.delivery.ShardSessionRecord;
+import io.spine.server.delivery.WorkerId;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Iterator;
@@ -165,9 +166,11 @@ public final class DsSessionStorage
                                  .getOfTotal());
         }),
 
-        node((m) -> {
-            return StringValue.of(m.getPickedBy()
-                                   .getValue());
+        worker((m) -> {
+            WorkerId worker = m.getWorker();
+            String value = worker.getNodeId().getValue() + '-' + worker.getValue();
+            return StringValue.of(value);
+
         }),
 
         when_last_picked((m) -> {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.gcloud:spine-datastore:1.7.0`
+# Dependencies of `io.spine.gcloud:spine-datastore:1.8.0`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.0 **No license information found**
@@ -592,12 +592,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 15 12:20:09 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 16 16:38:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-pubsub:1.7.0`
+# Dependencies of `io.spine.gcloud:spine-pubsub:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1003,12 +1003,12 @@ This report was generated on **Tue Dec 15 12:20:09 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 15 12:20:20 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 16 16:38:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.7.0`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:1.8.0`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.0 **No license information found**
@@ -1594,12 +1594,12 @@ This report was generated on **Tue Dec 15 12:20:20 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 15 12:20:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 16 16:39:04 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.7.0`
+# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:1.8.0`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.0 **No license information found**
@@ -2191,4 +2191,4 @@ This report was generated on **Tue Dec 15 12:20:43 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 15 12:20:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 16 16:39:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>1.7.0</version>
+<version>1.8.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -46,7 +46,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -98,44 +98,28 @@ all modules and does not describe the project structure per-subproject.
     <scope>test</scope>
   </dependency>
   <dependency>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>3.0.2</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
     <groupId>com.google.errorprone</groupId>
-    <artifactId>error_prone_core</artifactId>
+    <artifactId>error_prone_annotations</artifactId>
     <version>2.4.0</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
-    <artifactId>javac</artifactId>
-    <version>9+181-r4173-1</version>
+    <artifactId>error_prone_type_annotations</artifactId>
+    <version>2.4.0</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
-    <groupId>com.google.protobuf</groupId>
-    <artifactId>protoc</artifactId>
-    <version>3.13.0</version>
-  </dependency>
-  <dependency>
-    <groupId>io.grpc</groupId>
-    <artifactId>protoc-gen-grpc-java</artifactId>
-    <version>1.28.1</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.7.0</version>
-  </dependency>
-  <dependency>
-    <groupId>net.sourceforge.pmd</groupId>
-    <artifactId>pmd-java</artifactId>
-    <version>6.24.0</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jacoco</groupId>
-    <artifactId>org.jacoco.agent</artifactId>
-    <version>0.8.5</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jacoco</groupId>
-    <artifactId>org.jacoco.ant</artifactId>
-    <version>0.8.5</version>
+    <groupId>org.checkerframework</groupId>
+    <artifactId>checker-qual</artifactId>
+    <version>3.7.1</version>
+    <scope>provided</scope>
   </dependency>
 </dependencies>
 </project>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -31,6 +31,6 @@
  * `.config/gradle/dependencies.gradle`.
  */
 
-val spineBaseVersion: String by extra("1.7.0")
-val spineCoreVersion: String by extra("1.7.0")
-val versionToPublish: String by extra("1.7.0")
+val spineBaseVersion: String by extra("1.8.0")
+val spineCoreVersion: String by extra("1.8.0")
+val versionToPublish: String by extra("1.8.0")


### PR DESCRIPTION
This changeset releases the version `1.8.0`.

Other than migrating to the most recent versions of Spine libraries, it addresses the API change related to the changes in the `ShardSessionRecord` structure (see [core-java#1433](https://github.com/SpineEventEngine/core-java/pull/1433)).