### PR TITLE
Fix `ColumnPredicate` matching bugs (#195) and refresh local deps

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.413"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.420"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.420"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.053"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.054"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.053"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.054"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.077"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.079"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.077"
+    const val version = "2.0.0-SNAPSHOT.079"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.400"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.400"
+    const val version = "2.0.0-SNAPSHOT.401"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.401"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/datastore/src/main/java/io/spine/server/storage/datastore/query/ColumnPredicate.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/query/ColumnPredicate.java
@@ -123,9 +123,15 @@ final class ColumnPredicate<I, R extends Message> implements Predicate<Entity> {
     private boolean checkOr(Entity entity,
                             ImmutableList<SubjectParameter<?, ?, ?>> params,
                             ImmutableList<QueryPredicate<R>> children) {
-        return checkOrParams(entity, params)
-                || checkOrChildren(entity, children)
-                || params.isEmpty();
+        // A disjunction matches if any of its parameters or child predicates matches.
+        // An empty disjunction (no parameters and no children) imposes no constraint and
+        // therefore matches. The `children` must be taken into account here: an `OR` node
+        // with no own parameters but with child predicates (e.g. a composite `either(...)`)
+        // is still driven by those children. By design, this is intended to behave like the
+        // in-memory `RecordQueryMatcher` so that a query selects the same records either way.
+        return (params.isEmpty() && children.isEmpty())
+                || checkOrParams(entity, params)
+                || checkOrChildren(entity, children);
     }
 
     private boolean checkOrChildren(Entity entity, ImmutableList<QueryPredicate<R>> children) {

--- a/datastore/src/main/java/io/spine/server/storage/datastore/query/ColumnPredicate.java
+++ b/datastore/src/main/java/io/spine/server/storage/datastore/query/ColumnPredicate.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -68,7 +68,6 @@ final class ColumnPredicate<I, R extends Message> implements Predicate<Entity> {
     }
 
     @Override
-    @SuppressWarnings("FallThrough") // defines strategy for default and faulty values.
     public boolean test(@Nullable Entity entity) {
         if (entity == null) {
             return false;
@@ -92,7 +91,7 @@ final class ColumnPredicate<I, R extends Message> implements Predicate<Entity> {
                     "Unknown logical operator `%s`.", operator
             );
         };
-        return !match;
+        return match;
     }
 
     private boolean checkAnd(Entity entity,

--- a/datastore/src/test/kotlin/io/spine/server/storage/datastore/query/ColumnPredicateSpec.kt
+++ b/datastore/src/test/kotlin/io/spine/server/storage/datastore/query/ColumnPredicateSpec.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.datastore.query
+
+import com.google.cloud.datastore.Entity
+import com.google.cloud.datastore.Key
+import io.kotest.matchers.shouldBe
+import io.spine.server.storage.datastore.config.DsColumnMapping
+import io.spine.test.storage.StgProject
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests [ColumnPredicate] against its documented contract: `test(entity)` returns
+ * `true` when the entity matches the parameters of the query subject, and `false`
+ * otherwise.
+ *
+ * The class is reached only by the lookup-by-IDs read path
+ * ([io.spine.server.storage.datastore.query.DsLookupByIds]), which filters the
+ * fetched entities with `stream.filter(predicate)` — so an inverted result silently
+ * keeps the wrong records (see issue #195).
+ */
+@DisplayName("`ColumnPredicate` should")
+internal class ColumnPredicateSpec {
+
+    private val adapter = FilterAdapter.of(DsColumnMapping())
+
+    private val idColumn = StgProject.Column.idString().name().value()
+    private val internalColumn = StgProject.Column.internal().name().value()
+
+    private fun predicateFor(query: StgProject.Query) =
+        ColumnPredicate(query.subject(), adapter)
+
+    /** Builds an in-memory entity, setting only the columns passed as non-`null`. */
+    private fun entity(id: String? = null, internal: Boolean? = null): Entity {
+        val builder = Entity.newBuilder(key())
+        id?.let { builder.set(idColumn, it) }
+        internal?.let { builder.set(internalColumn, it) }
+        return builder.build()
+    }
+
+    private fun key(): Key = Key.newBuilder("test-project", "StgProject", "entity").build()
+
+    @Test
+    fun `reject a 'null' entity`() {
+        val predicate = predicateFor(StgProject.query().build())
+
+        predicate.test(null) shouldBe false
+    }
+
+    @Test
+    fun `match any entity when the query declares no parameters`() {
+        val predicate = predicateFor(StgProject.query().build())
+
+        predicate.test(entity(id = "anything")) shouldBe true
+    }
+
+    @Nested inner class
+    `With a conjunctive (AND) predicate` {
+
+        @Test
+        fun `match an entity that satisfies the only parameter`() {
+            val predicate = predicateFor(
+                StgProject.query().idString().`is`("42").build()
+            )
+
+            predicate.test(entity(id = "42")) shouldBe true
+        }
+
+        @Test
+        fun `reject an entity that violates the only parameter`() {
+            val predicate = predicateFor(
+                StgProject.query().idString().`is`("42").build()
+            )
+
+            predicate.test(entity(id = "99")) shouldBe false
+        }
+
+        @Test
+        fun `reject an entity that lacks the queried column`() {
+            val predicate = predicateFor(
+                StgProject.query().idString().`is`("42").build()
+            )
+
+            predicate.test(entity(internal = true)) shouldBe false
+        }
+
+        @Test
+        fun `match an entity that satisfies all parameters`() {
+            val predicate = predicateFor(
+                StgProject.query().idString().`is`("42").internal().`is`(true).build()
+            )
+
+            predicate.test(entity(id = "42", internal = true)) shouldBe true
+        }
+
+        @Test
+        fun `reject an entity that violates one of the parameters`() {
+            val predicate = predicateFor(
+                StgProject.query().idString().`is`("42").internal().`is`(true).build()
+            )
+
+            predicate.test(entity(id = "42", internal = false)) shouldBe false
+        }
+    }
+
+    @Nested inner class
+    `With a disjunctive (OR) predicate` {
+
+        @Test
+        fun `match an entity that satisfies one of the alternatives`() {
+            val predicate = predicateFor(
+                StgProject.query()
+                    .either({ it.idString().`is`("42") }, { it.idString().`is`("7") })
+                    .build()
+            )
+
+            predicate.test(entity(id = "7")) shouldBe true
+        }
+
+        @Test
+        fun `reject an entity that satisfies none of the alternatives`() {
+            val predicate = predicateFor(
+                StgProject.query()
+                    .either({ it.idString().`is`("42") }, { it.idString().`is`("7") })
+                    .build()
+            )
+
+            predicate.test(entity(id = "99")) shouldBe false
+        }
+
+        @Test
+        fun `match an entity that satisfies one of the alternative groups`() {
+            // Multi-parameter `either` branches become child `AND` predicates of the
+            // `OR` node, so this exercises the children recursion of the disjunction.
+            val predicate = predicateFor(
+                StgProject.query()
+                    .either(
+                        { it.idString().`is`("42").internal().`is`(true) },
+                        { it.idString().`is`("7").internal().`is`(false) }
+                    )
+                    .build()
+            )
+
+            predicate.test(entity(id = "42", internal = true)) shouldBe true
+        }
+
+        @Test
+        fun `match any entity for an OR predicate that declares no own parameters`() {
+            // A composite `either` yields an `OR` node whose own parameter list is empty
+            // (the parameters live in its child `AND` groups). `checkOr()` treats such a
+            // node as a match regardless of the children. This documents the existing
+            // fallback; issue #195 only corrects the result inversion, not this behavior.
+            val predicate = predicateFor(
+                StgProject.query()
+                    .either(
+                        { it.idString().`is`("42").internal().`is`(true) },
+                        { it.idString().`is`("7").internal().`is`(false) }
+                    )
+                    .build()
+            )
+
+            predicate.test(entity(id = "999", internal = true)) shouldBe true
+        }
+    }
+
+    @Nested inner class
+    `With a nested predicate` {
+
+        /** A query of the form `internal == true AND (idString == "42" OR idString == "7")`. */
+        private fun nestedPredicate() = predicateFor(
+            StgProject.query()
+                .internal().`is`(true)
+                .either({ it.idString().`is`("42") }, { it.idString().`is`("7") })
+                .build()
+        )
+
+        @Test
+        fun `match an entity satisfying the outer parameter and one alternative`() {
+            nestedPredicate().test(entity(id = "42", internal = true)) shouldBe true
+        }
+
+        @Test
+        fun `reject an entity that violates the outer parameter`() {
+            nestedPredicate().test(entity(id = "42", internal = false)) shouldBe false
+        }
+
+        @Test
+        fun `reject an entity that satisfies no inner alternative`() {
+            nestedPredicate().test(entity(id = "99", internal = true)) shouldBe false
+        }
+    }
+}

--- a/datastore/src/test/kotlin/io/spine/server/storage/datastore/query/ColumnPredicateSpec.kt
+++ b/datastore/src/test/kotlin/io/spine/server/storage/datastore/query/ColumnPredicateSpec.kt
@@ -171,11 +171,12 @@ internal class ColumnPredicateSpec {
         }
 
         @Test
-        fun `match any entity for an OR predicate that declares no own parameters`() {
+        fun `reject an entity that satisfies none of the alternative groups`() {
             // A composite `either` yields an `OR` node whose own parameter list is empty
-            // (the parameters live in its child `AND` groups). `checkOr()` treats such a
-            // node as a match regardless of the children. This documents the existing
-            // fallback; issue #195 only corrects the result inversion, not this behavior.
+            // (the parameters live in its child `AND` groups), so the disjunction must be
+            // driven by those children. The entity is a near miss: it matches the
+            // `idString` of the second group but not its `internal` value, so the `AND`
+            // within that group rejects it. With no group satisfied, the result is `false`.
             val predicate = predicateFor(
                 StgProject.query()
                     .either(
@@ -185,7 +186,55 @@ internal class ColumnPredicateSpec {
                     .build()
             )
 
-            predicate.test(entity(id = "999", internal = true)) shouldBe true
+            predicate.test(entity(id = "7", internal = true)) shouldBe false
+        }
+
+        @Test
+        fun `match any entity for a disjunction with no alternatives`() {
+            // A disjunction with neither own parameters nor children imposes no
+            // constraint, mirroring the in-memory `RecordQueryMatcher`.
+            val predicate = predicateFor(StgProject.query().either().build())
+
+            predicate.test(entity(id = "anything")) shouldBe true
+        }
+
+        /**
+         * A [ColumnPredicate] over a mixed disjunction:
+         * `idString == "42" OR (idString == "7" AND internal == false)`.
+         *
+         * The single-parameter branch becomes an own parameter of the `OR` node, while the
+         * two-parameter branch becomes a child `AND`, so the node carries both. The premise
+         * is asserted here so the tests below cannot silently degrade if the query model ever
+         * lowers `either(...)` differently.
+         */
+        private fun mixedDisjunction() = StgProject.query()
+            .either(
+                { it.idString().`is`("42") },
+                { it.idString().`is`("7").internal().`is`(false) }
+            )
+            .build()
+            .also {
+                val root = it.subject().predicate()
+                check(root.allParams().size == 1 && root.children().size == 1) {
+                    "Not a mixed disjunction: ${root.allParams().size} params," +
+                        " ${root.children().size} children."
+                }
+            }
+            .let { predicateFor(it) }
+
+        @Test
+        fun `match an entity via the own parameter`() {
+            mixedDisjunction().test(entity(id = "42")) shouldBe true
+        }
+
+        @Test
+        fun `match an entity via the child group`() {
+            mixedDisjunction().test(entity(id = "7", internal = false)) shouldBe true
+        }
+
+        @Test
+        fun `reject an entity matching neither the parameter nor the group`() {
+            mixedDisjunction().test(entity(id = "999", internal = true)) shouldBe false
         }
     }
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.gcloud:spine-datastore:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.gcloud:spine-datastore:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1276,14 +1276,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.gcloud:spine-pubsub:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.gcloud:spine-pubsub:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2156,14 +2156,14 @@ This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.gcloud:spine-stackdriver-trace:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3226,14 +3226,14 @@ This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.gcloud:spine-testutil-gcloud:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -4590,6 +4590,6 @@ This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 18:34:35 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1276,7 +1276,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:19:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2156,7 +2156,7 @@ This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:19:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3226,7 +3226,7 @@ This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:19:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4590,6 +4590,6 @@ This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 22 22:02:46 WEST 2026** using 
+This report was generated on **Mon Jun 22 22:19:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -44,7 +44,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.420</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.gcloud</groupId>
 <artifactId>spine-gcloud-java</artifactId>
-<version>2.0.0-SNAPSHOT.180</version>
+<version>2.0.0-SNAPSHOT.181</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -206,17 +206,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-cli-all</artifactId>
-    <version>2.0.0-SNAPSHOT.053</version>
+    <version>2.0.0-SNAPSHOT.054</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-protoc-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.053</version>
+    <version>2.0.0-SNAPSHOT.054</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>core-jvm-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.077</version>
+    <version>2.0.0-SNAPSHOT.079</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.180")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.181")


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in `io.spine.server.storage.datastore.query.ColumnPredicate` — the `Predicate<Entity>` consumed by the lookup-by-IDs read path (`DsLookupByIds`) via `stream.filter(predicate)` — and refreshes the lagging `local` Spine dependencies.

Closes #195.

## `ColumnPredicate` fixes

1. **Inverted match result (#195).** `testPredicate(...)` ended with `return !match`, so a matching entity yielded `false` and a non-matching one `true`; a column-filtered by-IDs query kept exactly the records that did *not* match and dropped those that did. Fixed to `return match`.
2. **Child-only disjunction matched everything.** `checkOr` fell back on `params.isEmpty()` alone, so an `OR` node with no own parameters but with child predicates (what a composite `either(...)` produces) matched unconditionally. Now guarded with `children.isEmpty()` too, restoring parity with the in-memory `RecordQueryMatcher.checkEither`.

The class had **0% test coverage**; this adds `ColumnPredicateSpec` (Kotlin + Kotest, 18 cases: `null` / empty / `AND` / `OR` flat·composite·empty·mixed / nested). Each fix was verified red → green.

## Dependencies

Refreshed `local` Spine deps to their latest published snapshots — Base `.413 → .420`, ToolBase `.400 → .401` (plus Compiler `.054`, CoreJvmCompiler `.079`) — and regenerated the dependency reports. Project version bumped to `2.0.0-SNAPSHOT.181`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
