### PR TITLE
Upgrade Testcontainers to 2.0.5

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
@@ -29,9 +29,9 @@ package io.spine.dependency.test
 // https://github.com/testcontainers/testcontainers-java
 @Suppress("unused", "ConstPropertyName")
 object Testcontainers {
-    private const val version = "1.21.4"
+    private const val version = "2.0.5"
     private const val group = "org.testcontainers"
     const val lib = "$group:testcontainers:$version"
-    const val junitJupiter = "$group:junit-jupiter:$version"
-    const val gcloud = "$group:gcloud:$version"
+    const val junitJupiter = "$group:testcontainers-junit-jupiter:$version"
+    const val gcloud = "$group:testcontainers-gcloud:$version"
 }

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.gcloud:spine-datastore:2.0.0-SNAPSHOT.213`
+# Dependencies of `io.spine.gcloud:spine-datastore:2.0.0-SNAPSHOT.214`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -418,15 +418,15 @@
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-api. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-api. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-transport. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-transport. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-transport-zerodep. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-transport-zerodep. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -706,6 +706,10 @@
      * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.20.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : dev.zacsweers.autoservice. **Name** : auto-service-ksp. **Version** : 1.2.0.
      * **Project URL:** [https://github.com/ZacSweers/auto-service-ksp](https://github.com/ZacSweers/auto-service-ksp)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -869,7 +873,7 @@
      * **Project URL:** [https://github.com/trustin/os-maven-plugin/](https://github.com/trustin/os-maven-plugin/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.13.0.
+1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.18.1.
      * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
@@ -899,8 +903,12 @@
      * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
      * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
 
-1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.24.0.
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.28.0.
      * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.18.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-lang/](https://commons.apache.org/proper/commons-lang/)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.20.0.
@@ -1249,11 +1257,11 @@
      * **Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **License:** [MIT](https://opensource.org/license/mit)
 
-1.  **Group** : org.testcontainers. **Name** : gcloud. **Version** : 1.21.4.
+1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 2.0.5.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 1.21.4.
+1.  **Group** : org.testcontainers. **Name** : testcontainers-gcloud. **Version** : 2.0.5.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
@@ -1276,14 +1284,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 25 20:51:14 WEST 2026** using 
+This report was generated on **Sat Jun 27 21:50:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.gcloud:spine-pubsub:2.0.0-SNAPSHOT.213`
+# Dependencies of `io.spine.gcloud:spine-pubsub:2.0.0-SNAPSHOT.214`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2156,14 +2164,14 @@ This report was generated on **Thu Jun 25 20:51:14 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using 
+This report was generated on **Sat Jun 27 21:50:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gcloud-testlib:2.0.0-SNAPSHOT.213`
+# Dependencies of `io.spine.tools:gcloud-testlib:2.0.0-SNAPSHOT.214`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2180,15 +2188,15 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-api. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-api. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-transport. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-transport. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-transport-zerodep. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-transport-zerodep. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2345,6 +2353,10 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.20.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : io.grpc. **Name** : grpc-alts. **Version** : 1.81.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
@@ -2457,17 +2469,17 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 
-1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
-     * **Project URL:** [http://junit.org](http://junit.org)
-     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.13.0.
+1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.18.1.
      * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
 
-1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.24.0.
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.28.0.
      * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.18.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-lang/](https://commons.apache.org/proper/commons-lang/)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.14.
@@ -2489,14 +2501,6 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
 1.  **Group** : org.conscrypt. **Name** : conscrypt-openjdk-uber. **Version** : 2.5.2.
      * **Project URL:** [https://conscrypt.org/](https://conscrypt.org/)
      * **License:** [Apache 2](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 3.0.
-     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
-     * **License:** [BSD-3-Clause](https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 3.0.
-     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
-     * **License:** [BSD-3-Clause](https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE)
 
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
@@ -2582,11 +2586,11 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **License:** [MIT](https://opensource.org/license/mit)
 
-1.  **Group** : org.testcontainers. **Name** : gcloud. **Version** : 1.21.4.
+1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 2.0.5.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 1.21.4.
+1.  **Group** : org.testcontainers. **Name** : testcontainers-gcloud. **Version** : 2.0.5.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
@@ -2662,15 +2666,15 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-api. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-api. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-transport. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-transport. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.docker-java. **Name** : docker-java-transport-zerodep. **Version** : 3.4.2.
+1.  **Group** : com.github.docker-java. **Name** : docker-java-transport-zerodep. **Version** : 3.7.1.
      * **Project URL:** [https://github.com/docker-java/docker-java](https://github.com/docker-java/docker-java)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2950,6 +2954,10 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.20.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : dev.zacsweers.autoservice. **Name** : auto-service-ksp. **Version** : 1.2.0.
      * **Project URL:** [https://github.com/ZacSweers/auto-service-ksp](https://github.com/ZacSweers/auto-service-ksp)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3113,7 +3121,7 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [https://github.com/trustin/os-maven-plugin/](https://github.com/trustin/os-maven-plugin/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.13.0.
+1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.18.1.
      * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
@@ -3143,8 +3151,12 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
      * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
 
-1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.24.0.
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.28.0.
      * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.18.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-lang/](https://commons.apache.org/proper/commons-lang/)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.20.0.
@@ -3493,11 +3505,11 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
      * **Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **License:** [MIT](https://opensource.org/license/mit)
 
-1.  **Group** : org.testcontainers. **Name** : gcloud. **Version** : 1.21.4.
+1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 2.0.5.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 1.21.4.
+1.  **Group** : org.testcontainers. **Name** : testcontainers-gcloud. **Version** : 2.0.5.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
@@ -3520,6 +3532,6 @@ This report was generated on **Thu Jun 25 20:51:13 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 25 20:51:14 WEST 2026** using 
+This report was generated on **Sat Jun 27 21:50:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.gcloud</groupId>
 <artifactId>gcloud-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.213</version>
+<version>2.0.0-SNAPSHOT.214</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -109,14 +109,14 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.testcontainers</groupId>
-    <artifactId>gcloud</artifactId>
-    <version>1.21.4</version>
+    <artifactId>testcontainers</artifactId>
+    <version>2.0.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>org.testcontainers</groupId>
-    <artifactId>testcontainers</artifactId>
-    <version>1.21.4</version>
+    <artifactId>testcontainers-gcloud</artifactId>
+    <version>2.0.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/testlib/src/main/java/io/spine/testing/server/storage/datastore/EmulatorContainer.java
+++ b/testlib/src/main/java/io/spine/testing/server/storage/datastore/EmulatorContainer.java
@@ -6,7 +6,7 @@ import com.google.cloud.datastore.DatastoreOptions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.server.storage.datastore.ProjectId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.testcontainers.containers.DatastoreEmulatorContainer;
+import org.testcontainers.gcloud.DatastoreEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import static java.util.Objects.requireNonNull;

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.213")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.214")


### PR DESCRIPTION
## Summary

Completes the follow-up in #191 — evaluate the Testcontainers **2.x** line and
adopt it. The main fix (`1.21.4`) already landed; this PR moves to **2.0.5**.

Testcontainers 2.0 renamed the GCP module artifact and relocated the container
class:

- `org.testcontainers:gcloud` → `org.testcontainers:testcontainers-gcloud`
  (the old coordinate's last release is `1.21.4`; `2.0.5` is only published
  under the new, prefixed name)
- `org.testcontainers.containers.DatastoreEmulatorContainer` →
  `org.testcontainers.gcloud.DatastoreEmulatorContainer`

A version-only bump (the dependency-update cadence) could not have crossed the
1.x → 2.x boundary because of the rename; this one-time structural change does
it. Future 2.x bumps ride the cadence normally.

## Changes

- **`Testcontainers.kt`** — `1.21.4` → `2.0.5`; coordinates `gcloud` →
  `testcontainers-gcloud`, `junit-jupiter` → `testcontainers-junit-jupiter`.
- **`EmulatorContainer.java`** — import → `org.testcontainers.gcloud.DatastoreEmulatorContainer`.
  The overridden members (`configure()`, `getEmulatorEndpoint()`,
  `getProjectId()`, `start()`) are unchanged in 2.x.
- **Dependency reports** regenerated — docker-java `3.4.2` → **`3.7.1`**; the
  JUnit 4 / Hamcrest transitives dropped (2.0 removed JUnit 4 support).
- **Version** → `2.0.0-SNAPSHOT.214`.

## Why it's safe

- TC 2.x still targets Java 8 bytecode (`options.release.set(8)`), so JDK 17 is
  unaffected.
- The `DatastoreEmulatorContainer` API our subclass overrides is unchanged
  (compile-verified — javac accepts the overrides).

## Verification

- `:testlib` + `:datastore` main & test sources compile; `checkstyle` + `pmd`
  pass; the `dependency-audit` reviewer approved.
- The Datastore-emulator suites were **not** run in the dev session (no Docker
  there; the `CheckDockerAvailable` gate hard-requires it) — they run here on CI.

Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
